### PR TITLE
Update RoR ActionController link

### DIFF
--- a/source/tweaks-in-your-code/filter-parameter-logging.html.md
+++ b/source/tweaks-in-your-code/filter-parameter-logging.html.md
@@ -53,7 +53,7 @@ You can of course let the lambda do anything you'd like, so you can come
 up with your own way of determining what needs to be filtered.
 
 Some further information about filtering parameters can be found in the Rails
-guide about [ActionController](http://guides.rubyonrails.org/action_controller_overview.html#parameter-filtering).
+guide about [ActionController](http://guides.rubyonrails.org/action_controller_overview.html#parameters-filtering).
 
 ## Filter all parameters
 


### PR DESCRIPTION
Updates the Ruby on Rails guide ActionController link to point to the accurate anchor for the Parameters Filtering section.