### PR TITLE
Suggest using safe navigation for error.stack

### DIFF
--- a/source/tweaks-in-your-code/frontend-error-catching.html.md
+++ b/source/tweaks-in-your-code/frontend-error-catching.html.md
@@ -122,7 +122,7 @@ class @Appsignal
       action:    @action
       message:   error.message
       name:      error.name
-      backtrace: error.stack.split("\n")
+      backtrace: error.stack?.split("\n")
       path:      window.location.pathname
       tags:      @tags
       environment: {


### PR DESCRIPTION
Apperantly, `error.stack` is not standard and will be unavailable in some cases, which was causing us an exception-in-an-exception

https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Error/stack