### PR TITLE
No more manual middleware inclusion for Sinatra

### DIFF
--- a/source/getting-started/supported-frameworks.html.md
+++ b/source/getting-started/supported-frameworks.html.md
@@ -43,13 +43,7 @@ To install follow the installation steps in AppSignal, start by clicking 'Add ap
 [Sinatra](http://www.sinatrarb.com/) is officially supported, but requires a bit of manual configuration.
 Follow the installation steps in AppSignal, start by clicking 'Add app' on [the accounts screen](https://appsignal.com/accounts).
 
-After installing the gem you need to add `require 'appsignal/integrations/sinatra'` beneath `require 'sinatra'` in your app.
-If you define your app at the top-level this works straight away. If your app is a subclass of `Sinatra::Base` you need to use these middlewares:
-
-```ruby
-class MyApp < Sinatra::Base
-  use Appsignal::Rack::SinatraInstrumentation
-```
+After installing the gem you need to add `require 'appsignal/integrations/sinatra'` beneath `require 'sinatra'` or `require 'sinatra/base'` in your app.
 
 After this, add an `appsignal.yml` config file to `/config`. You can find your `push_api_key` by clicking 'Add app' on [the accounts screen](https://appsignal.com/accounts).
 Or you can use [Environment variables to configure the gem](/gem-settings/env-vars.html).

--- a/source/getting-started/supported-frameworks.html.md
+++ b/source/getting-started/supported-frameworks.html.md
@@ -48,6 +48,8 @@ After installing the gem you need to add `require 'appsignal/integrations/sinatr
 After this, add an `appsignal.yml` config file to `/config`. You can find your `push_api_key` by clicking 'Add app' on [the accounts screen](https://appsignal.com/accounts).
 Or you can use [Environment variables to configure the gem](/gem-settings/env-vars.html).
 
+Since appsignal gem version 1.3 you no longer need to manually include the `Appsignal::Rack::SinatraInstrumentation` middleware in your application. Please remove it.
+
 <a name="padrino"></a>
 # Padrino
 


### PR DESCRIPTION
From: https://github.com/appsignal/appsignal-ruby-private/pull/297

Is this enough or do we also want to keep the pre-1.3.0 method in the documentation for older installs?