### PR TITLE
Fix typos and remove empty lines

### DIFF
--- a/source/background-monitoring/custom.html.md
+++ b/source/background-monitoring/custom.html.md
@@ -19,7 +19,7 @@ A transaction needs an unique id and the environment hash, you can use your back
 
 ### Add instrumentation
 
-The gem differentiates background jobs from web requests by listening to certain instrumentation messages. At the mimimum we need at least one message with the fields below. Any other instrumentation message (database calls etc.) will also be added to the transaction, so you can view them in the AppSignal interface.
+The gem differentiates background jobs from web requests by listening to certain instrumentation messages. At the minimum we need at least one message with the fields below. Any other instrumentation message (database calls etc.) will also be added to the transaction, so you can view them in the AppSignal interface.
 
 | Parameter | Description|
 | ------ | ------ |
@@ -113,7 +113,7 @@ end
 
 
 ### A full example (2)
-A full example from the Sidekiq implemenation (note: does not work with v1.1.2)
+A full example from the Sidekiq implementation (note: does not work with v1.1.2)
 
 ``` ruby
 def call(worker, item, queue)

--- a/source/background-monitoring/delayed-job.html.md
+++ b/source/background-monitoring/delayed-job.html.md
@@ -41,6 +41,4 @@ class StructJobWithName < Struct.new(:id)
   end
 
 end
-
 ```
-

--- a/source/background-monitoring/rake.html.md
+++ b/source/background-monitoring/rake.html.md
@@ -3,7 +3,7 @@
 
 With AppSignal gem version `0.11.13`, we've added Rake task monitoring.
 
-Simply add `require 'appsignal/integrations/rake'` to your RakeFile like this:
+Simply add `require 'appsignal/integrations/rake'` to your Rakefile like this:
 
 ```ruby
 #!/usr/bin/env rake
@@ -27,7 +27,7 @@ namespace :mycrazyproject do
     while true
       User.where(active:true).find_in_batches(batch_size:20).with_index do |batch_of_users, batch_ndx|
         # We collect a bunch of new threads, one for each
-        # user, eac 
+        # user, each...
         #
         batch_threads = batch_of_users.collect do |user_outer|
           Thread.new(user_outer) do |u|
@@ -54,7 +54,6 @@ namespace :mycrazyproject do
         #
         batch_threads.map(&:join)
       end
-      ##########
     end
   end
 end

--- a/source/background-monitoring/sidekiq.html.md
+++ b/source/background-monitoring/sidekiq.html.md
@@ -8,5 +8,4 @@ Starting with AppSignal gem version 8.0 or higher we monitor Sidekiq and Delayed
 
 [Sidekiq](http://sidekiq.org) is a simple and efficient background processor for Ruby. It's also the processor we use to process jobs in AppSignal.
 
-The AppSignal gem inserts a listener into the Sidekiq server middlware stack if the `Sidekiq` module is present. No further action is required.
-
+The AppSignal gem inserts a listener into the Sidekiq server middleware stack if the `Sidekiq` module is present. No further action is required.

--- a/source/gem-settings/configuration.html.md
+++ b/source/gem-settings/configuration.html.md
@@ -176,5 +176,4 @@ production:
 
   # We can't connect to the outside world without this proxy
   http_proxy: 'proxy.mydomain.com:8080'
-
 ```

--- a/source/gem-settings/ignore-actions.md
+++ b/source/gem-settings/ignore-actions.md
@@ -2,7 +2,7 @@
 title: "Ignore actions"
 ---
 
-Sometimes you have a certain action that you don't need to log to AppSignal. The most common use case is an action that your loadbalancer uses to check if your app is still responding.
+Sometimes you have a certain action that you don't need to log to AppSignal. The most common use case is an action that your load balancer uses to check if your app is still responding.
 
 You can ignore these actions from being sent to AppSignal in the gem config. This works both for controller and for background jobs.
 

--- a/source/getting-started/custom-metrics.html.md
+++ b/source/getting-started/custom-metrics.html.md
@@ -76,11 +76,11 @@ Each dashboard consists of a title and one or more graphs. For each graph the fo
 | Field | Type | Description  |
 | ------ | ------ | ----- |
 |  title  |  string  |  title of the graph  |
-|  [kind](#kind)  |  string  |  the kind of metrics to display, available options are "gauge, measurement and count". This determins the group of metrics where data can be graphed. See the "Sample fields from the last five minutes" section of the metrics editor to see what groups and fields are available.  |
+|  [kind](#kind)  |  string  |  the kind of metrics to display, available options are "gauge, measurement and count". This determines the group of metrics where data can be graphed. See the "Sample fields from the last five minutes" section of the metrics editor to see what groups and fields are available.  |
 |  [format](#format)  |  string  |  the formatter for the data, options are "number, size, percent, duration, throughput"  |
 |  [fields](#fields)  |  array (strings)  |  an array of fields to graph |
-|  [filter](#filter)  |  string (Regex)  |  a regex, maching fields will be graphed  |
-|  [`draw_null_as_zero`](#draw_null_as_zero) | boolean (true/false), defaults to true | Graphs have two render options, if `draw_null_as_zero` is true (default) then if no vaule is received it will draw that point as 0, if `draw_null_as_zero` is set to false, then the previous value will be used, until a new value is received.
+|  [filter](#filter)  |  string (Regex)  |  a regex, matching fields will be graphed  |
+|  [`draw_null_as_zero`](#draw_null_as_zero) | boolean (true/false), defaults to true | Graphs have two render options, if `draw_null_as_zero` is true (default) then if no value is received it will draw that point as 0, if `draw_null_as_zero` is set to false, then the previous value will be used, until a new value is received.
 
 ## Kind <a name="kind"></a>
 
@@ -90,7 +90,7 @@ There are three kinds of metrics we collect, "gauge, measurement and count".
 | ------ | ----- |
 |  gauge  | A gauge contains a number, if another gauge with the same key is set, the highest number will be persisted. |
 |  measurement  |  A measurement contains a duration of time, when multiple measurements with the same key are set, the average will be persisted. |
-|  count  | A count is a number that can be incremented, when multiple counts with the same key are set, the count is incremented by the vaule of each key. |
+|  count  | A count is a number that can be incremented, when multiple counts with the same key are set, the count is incremented by the value of each key. |
 
 
 ## Format <a name="format"></a>
@@ -99,11 +99,11 @@ For the graphs we have a number of formatters available for the data.
 
 | Format |  Description  |
 | ------ | ----- |
-|  number  | A formatted number, 1_000_000 wil become `1M` 10_000 will become `10K` |
+|  number  | A formatted number, 1_000_000 will become `1M` 10_000 will become `10K` |
 |  size  |  Size formatted from megabytes. 1.0 megabytes will become `1Mb` |
 |  percent  | A percentage, 40 will become `40%` |
-|  duration  | A duration of time in miliseconds. 100 will become `100ms` 60_000 will become `60sec` Mosly used for measurements. |
-|  throughput  | Throughput of a metric. It will display the troughput formatted as a number for both the minute and the hour. 10_000 will become `10k / hour 166/min`, Mostly used for count fields. |
+|  duration  | A duration of time in milliseconds. 100 will become `100ms` 60_000 will become `60sec`. Mostly used for measurements. |
+|  throughput  | Throughput of a metric. It will display the throughput formatted as a number for both the minute and the hour. 10_000 will become `10k / hour 166/min`, Mostly used for count fields. |
 
 ##  Fields <a name="fields"></a>
 
@@ -118,7 +118,7 @@ A list of available fields per group can be found on the metric editor page.
 
 ## Filter <a name="filter"></a>
 
-When using a filter, all fields matching the given (Javascript)regex will be graphed. You can either use an array of fields, or a filter.
+When using a filter, all fields matching the given (JavaScript)regex will be graphed. You can either use an array of fields, or a filter.
 
 ```yaml
 filter: "db_[a-z]+._size"
@@ -132,7 +132,7 @@ This filter will match any field that begins with `db_` and ends with `_size`, f
 
 ## Draw NULL as zero <a name="draw_null_as_zero"></a>
 
-There are two options to render lines, if `draw_null_as_zero` is `true` (default) then if no vaule is received it will draw that point as 0, if `draw_null_as_zero` is set to `false`, then the previous value will be used, until a new value is received.
+There are two options to render lines, if `draw_null_as_zero` is `true` (default) then if no value is received it will draw that point as 0, if `draw_null_as_zero` is set to `false`, then the previous value will be used, until a new value is received.
 
 ![draw null as zero](/images/screenshots/draw_null_as_zero.png)
 

--- a/source/getting-started/how-appsignal-operates.html.md
+++ b/source/getting-started/how-appsignal-operates.html.md
@@ -3,7 +3,7 @@ title: How AppSignal operates
 ---
 
 When you install the `appsignal` gem a native extension is compiled. You therefore need a working C compiler on the machine where you bundle. Most of the times
-this is already present, if not you can run `apt-get build-essential` on Debian style systems or `yum groupinstall 'Development Tools'` on Redhat style systems.
+this is already present, if not you can run `apt-get build-essential` on Debian style systems or `yum groupinstall 'Development Tools'` on Red Hat style systems.
 
 Once you boot your application for the first time after installing our gem the AppSignal agent will be started. This agent tries to locate a proper directory
 to place it's files. If you use a Capistrano style directory structure it will create a directory in `app/shared`. On Heroku style deployments

--- a/source/getting-started/integrations/intercom.html.md
+++ b/source/getting-started/integrations/intercom.html.md
@@ -58,7 +58,7 @@ Deploy this change to your server.
 
 ### Step 2: Retrieve the Intercom app id and API key
 
-In the Intercom app, click the settings button on the top right and go to "Intergrations for [Your app name]".
+In the Intercom app, click the settings button on the top right and go to "Integrations for [Your app name]".
 
 ![api_key](/images/screenshots/intercom/api_keys.png)
 Note the App id (1) and create a new read/write API key (2). Note this new key (3) as well.

--- a/source/getting-started/integrations/jira.html.md
+++ b/source/getting-started/integrations/jira.html.md
@@ -21,7 +21,7 @@ After saving the integration, click "Edit" and go to the "Incoming Oauth" tab in
 
 ### OAuth setup
 
-In the "Incoming Oauth" tab, setup OAuth with the following values:
+In the "Incoming OAuth" tab, setup OAuth with the following values:
 
 * Consumer Key: <code>7668c385bf3f09c0219ec178a50ff736</code>
 * Consumer Name: <code>AppSignal</code>

--- a/source/getting-started/lifecycle.html.md
+++ b/source/getting-started/lifecycle.html.md
@@ -31,4 +31,4 @@ Once every few seconds a process starts that takes all the data from the "bucket
 
 In a worst case scenario it can take up to 90 seconds from request to sample on the performance page. We're constantly trying to minimize this time, but we have to balance the amount of requests our push api receives and data size of each request with processing speed.
 
-If you would like to know more about this subject, don't hesistate to [contact us](mailto:contact@appsignal.com)!
+If you would like to know more about this subject, don't hesitate to [contact us](mailto:contact@appsignal.com)!

--- a/source/getting-started/manage-app-settings.html.md
+++ b/source/getting-started/manage-app-settings.html.md
@@ -9,10 +9,10 @@ in the main menu after you've navigated to an app.
 
 See [set up a new app](/getting-started/set-up-a-new-app.html) for more information about creating a new site.
 
-If your app is not connected to a repository on Github you can connect
+If your app is not connected to a repository on GitHub you can connect
 it. If it is connected you can change the linked repository. You need to authenticate
-with Github to use this feature. You can either do this by signing in
-via Github, or by linkin your Github account in your [user
+with GitHub to use this feature. You can either do this by signing in
+via GitHub, or by linking your GitHub account in your [user
 setttings](/getting-started/your-user-account.html). An app linked to GitHub gives you additional features like direct links to commits.
 
 ## [People](#people)

--- a/source/getting-started/supported-frameworks.html.md
+++ b/source/getting-started/supported-frameworks.html.md
@@ -183,7 +183,7 @@ Webmachine works with AppSignal `1.3` and up.
 A Webmachine app requires a few manual steps to get working.
 
 * Place an `appsignal.yml` config file in `/config` (or use [ENV VARS](/gem-settings/configuration.html))
-* Make sure AppSignal is requried (`require 'appsignal').
+* Make sure AppSignal is required (`require 'appsignal').
 * Configure AppSignal (`Appsignal.config`)
 * Start Appsignal logger (`Appsignal.start_logger`)
 * Start AppSignal (`Appsignal.start`)

--- a/source/getting-started/webhooks.html.md
+++ b/source/getting-started/webhooks.html.md
@@ -2,7 +2,7 @@
 title: "Webhooks"
 ---
 
-AppSignal can send notifications of new incidents to serveral services, like Campfire and Slack. We also offer webhooks for these notifications.
+AppSignal can send notifications of new incidents to several services, like Campfire and Slack. We also offer webhooks for these notifications.
 
 To receive a webhook, go to the "Integrations" tab the site's sidebar and fill out the url where you'd like to receive your webhook data.
 

--- a/source/getting-started/your-user-account.html.md
+++ b/source/getting-started/your-user-account.html.md
@@ -8,7 +8,7 @@ being monitored.
 
 ## [Sign up](#log_in)
 When you are invited to an existing account or sign up, you can choose to sign
-up using Github or use an email / password combination.
+up using GitHub or use an email / password combination.
 
 ## [Change personal settings](#change_your_personal_settings)
 Once you're logged in you can navigate to your settings page by using
@@ -18,9 +18,9 @@ personal setting screens.
 ### [Personal](#personal)
 
 In personal settings you can change your name and password. If you
-haven't linked your Github account during sign-up, you can still do so here.
-Connecting your Github account gives you additional features like direct links
-to commits and linked stacktrace lines
+haven't linked your GitHub account during sign-up, you can still do so here.
+Connecting your GitHub account gives you additional features like direct links
+to commits and linked stack trace lines.
 
 ### [Notifications](#notifications)
 
@@ -52,7 +52,7 @@ umbrellas for your apps and the billing happens on the organization level.
 
 ### [Create a new organization](#create_organization)
 You can start a new organization with the "new organization" button. Because
-you'll probably work with new people and apps in this organziation, you'll have
+you'll probably work with new people and apps in this organization, you'll have
 a 30 day trial period again for this organization.
 
 ### [Leaving an organization](#leaving_an_organization)
@@ -62,4 +62,3 @@ access to. If you're not the only owner of the organization you can
 leave an organization. Once you do that you will not have access to the
 organization anymore, the only way to undo this is asking the owner to
 invite you again.
-

--- a/source/heroku/addon-doc.html.md
+++ b/source/heroku/addon-doc.html.md
@@ -49,7 +49,7 @@ Retrieve the api-key using the `heroku config:get` command.
 
 After installing the gem and deploying your application, it will start aggregating and sending data to AppSignal.
 
-Add the gem to the GemFile
+Add the gem to the Gemfile
 
     :::term
     gem 'appsignal'
@@ -100,7 +100,7 @@ AppSignal likes to know when you have deployed your app. We use deploys to measu
 
 ### Using multiple deploy hooks
 
-Unfortunately Heroku only supports one http deploy hook per site. Luckily one of our customers created a simple heroku app to fix this issue: https://github.com/deadlyicon/deploy-hook-forker
+Unfortunately Heroku only supports one http deploy hook per site. Luckily one of our customers created a simple Heroku app to fix this issue: https://github.com/deadlyicon/deploy-hook-forker
 
 ## Using our config file
 
@@ -118,7 +118,7 @@ If you deploy your application AppSignal will now use the api-key contained in t
 
 ## Adding integration gems
 
-AppSignal supports various other databases like Mongo and Redis. You can add an integration gem for this to your project.
+AppSignal supports various other databases like MongoDB and Redis. You can add an integration gem for this to your project.
 Read more [here](http://docs.appsignal.com/tweaks-in-your-code/integration-gems.html).
 
 ## Migrating between plans

--- a/source/push-api/deploy-marker.html.markdown
+++ b/source/push-api/deploy-marker.html.markdown
@@ -24,5 +24,4 @@ A curl example:
 
 ```
   curl -X POST -d "{\"revision\":\"ba70cebcd05d131e00e776b35616d7bc0ba919fb\",\"repository\":\"master\",\"user\":\"test user\"}" "https://push.appsignal.com/1/markers?api_key=abc&name=test&environment=production"
-
 ```

--- a/source/tweaks-in-your-code/filter-parameter-logging.html.md
+++ b/source/tweaks-in-your-code/filter-parameter-logging.html.md
@@ -34,7 +34,7 @@ keys they will not be filtered.
 ## [Allowing specific keys - Whitelisting](#whitelisting)
 
 If you use a lambda instead of a list of keys you get a lot of
-flexiblity. In the following example we use a lambda to setup a
+flexibility. In the following example we use a lambda to setup a
 whitelist instead of a blacklist.
 
 ```ruby

--- a/source/tweaks-in-your-code/frontend-error-catching.html.md
+++ b/source/tweaks-in-your-code/frontend-error-catching.html.md
@@ -4,7 +4,7 @@ title: "Frontend error catching (beta)"
 
 This is a Beta implementation, which means:
 
-* There is no official Javascript library supported by AppSignal.
+* There is no official JavaScript library supported by AppSignal.
 * The API might change in the future to support more frameworks.
 * This feature is not enabled by default and requires a setup that uses an appsignal.yml config file.
 
@@ -33,7 +33,7 @@ staging:
 
 ### Path
 
-The Rack middleware wil expose the following error catcher path `/appsignal_error_catcher`. You can change this path by adding `frontend_error_catching_path` to your `appsignal.yml` config file:
+The Rack middleware will expose the following error catcher path `/appsignal_error_catcher`. You can change this path by adding `frontend_error_catching_path` to your `appsignal.yml` config file:
 
 ```yml
 staging:
@@ -88,7 +88,7 @@ set the error will not be processed.
 
 ## A sample implementation in CoffeeScript
 
-Currently we do not provide a Javascript library that catches frontend errors.
+Currently we do not provide a JavaScript library that catches frontend errors.
 The (coffee)script below is something we use to test the functionality, use and modify at your own risk.
 
 
@@ -143,7 +143,7 @@ appsignal        = new Appsignal
 window.appsignal = appsignal
 
 window.onerror = (message, filename, lineno, colno, error) ->
-  if error  
+  if error
     appsignal.sendError(error)
   else
     appsignal.sendError(new Error('Null error raised, no exception message available'))
@@ -151,6 +151,6 @@ window.onerror = (message, filename, lineno, colno, error) ->
 
 Here at AppSignal we're very keen on "eating our own dogfood". This means we use AppSignal to monitor AppSignal and since we're rewriting most of our frontend code to ReactJS we decided that we need to monitor it.
 
-Once we get a good feel of the requirements for Javascript error catching we plan on supporting an offical library that hopefully will support vanilla JS and all the popular frontend frameworks.
+Once we get a good feel of the requirements for JavaScript error catching we plan on supporting an official library that hopefully will support vanilla JS and all the popular frontend frameworks.
 
 You are welcome to try frontend error catching as well and we really like to hear feedback on our implementation. If you have any questions or suggestions, don't hesitate to contact us on <a href="mailto:contact@appsignal.com">contact@appsignal.com</a>.


### PR DESCRIPTION
Fixing some typos, wrong capitalization in names and removing empty lines from code examples and such.

This was a quick scan from what vim highlighted to me was wrong, a more in-depth read should be done later. 