### PR TITLE
Add heading anchors and links

### DIFF
--- a/lib/appsignal_markdown.rb
+++ b/lib/appsignal_markdown.rb
@@ -24,6 +24,13 @@ class AppsignalMarkdown < Middleman::Renderers::MiddlemanRedcarpetHTML
     add_custom_tags("<p>#{text.strip}</p>\n")
   end
 
+  # Add anchor tags to every heading.
+  # Create a link from the heading.
+  def header(text, level)
+    anchor = text.parameterize
+    %(<h%s id="%s"><a href="#%s">%s</a></h%s>) % [level, anchor, anchor, text, level]
+  end
+
   private
 
   # Add custom tags to content


### PR DESCRIPTION
This adds anchors back to every heading and also makes the headings
links. :with_toc_data from Redcarpet doesn't work because we make the
headings links, but also because we use a custom renderer and the way
Middleman loads custom renders, the config is lost for custom renderers.
