### PR TITLE
Tweaks heading and paragraph spacing

### DIFF
--- a/source/stylesheets/modules/_article.css.sass
+++ b/source/stylesheets/modules/_article.css.sass
@@ -14,25 +14,34 @@
     border-bottom: 1px solid $border
     padding-bottom: 10px
 
-  h3, h4, h5
-    @extend %h-small
+  h3, h4
     margin-bottom: 5px
+
+  h3
+    @extend %h-small
+
+  h4
+    @extend %h-tiny
 
   h1, h2, h3, h4
     a
       color: $font-heading
       text-decoration: none
 
-  p + h1,
-  p + h2,
-  p + h3
+  p + h2
     margin-top: 40px
+
+  p + h3
+    margin-top: 30px
+
+  p + h4
+    margin-top: 20px
 
   p, ul, ol
     color: $font-subheading
 
   p
-    margin-bottom: 30px
+    margin-bottom: 15px
 
   .intro
     @extend %t-large

--- a/source/stylesheets/utilities/_placeholders.css.sass
+++ b/source/stylesheets/utilities/_placeholders.css.sass
@@ -40,11 +40,13 @@
 %h-normal
   +font-weight(normal)
   line-height: 1.5
-  font-size: 20px
+  font-size: 24px
 
 %h-small
   +font-weight(bold)
   line-height: 1.5
-  // font-size: 13px
-  // letter-spacing: 1px
-  // text-transform: uppercase
+  font-size: 20px
+
+%h-tiny
+  +font-weight(bold)
+  line-height: 1.5


### PR DESCRIPTION
With more content and with more headings the usage of h3 and h4s was
confusing. Also decreased the spacing around the headings so that the
higher level headings create more spacing between sections than lower
level headings.

We should avoiding using a heading lower than h4.

In short this PR:

- Makes the distance between paragraphs smaller
- Gives h3 a bigger font size
- Tweaks the distance between headings and paragraphs.

## Before

![image](https://cloud.githubusercontent.com/assets/282402/19895394/ea9d75b0-a050-11e6-9ef7-059a3ed6aecd.png)

## After

![image](https://cloud.githubusercontent.com/assets/282402/19895371/ce9aae5a-a050-11e6-863b-d8829f081872.png)
