### PR TITLE
Update CoffeeScript Object Loop

### DIFF
--- a/source/front-end/error-handling.html.md
+++ b/source/front-end/error-handling.html.md
@@ -114,7 +114,7 @@ class @Appsignal
     @action = action
 
   tag_request: (tags) ->
-    for key in tags
+    for key or tags
       @tags[key] = tags[key]
 
   sendError: (error) ->


### PR DESCRIPTION
Since tags are really a hash/object `or` should be used to loop. `in` creates an array loop so `@tags` never gets populated.