### PR TITLE
Update Elixir docs to show how to set params for filtering

### DIFF
--- a/source/elixir/configuration/parameter-filtering.html.md
+++ b/source/elixir/configuration/parameter-filtering.html.md
@@ -29,6 +29,6 @@ AppSignal configuration file.
 
 ```elixir
 # config/config.exs
-config :appsignal,
-  :filter_parameters, ["password", "secret"]
+config :appsignal, :config,
+  filter_parameters: ["password", "secret"]
 ```


### PR DESCRIPTION
Related to this PR https://github.com/appsignal/appsignal-elixir/pull/73. The code uses `Application.get_env(:appsignal, :config)[:filter_parameters]`, so `filter_parameters` needs to be set in `config`. 