### PR TITLE
Fix heading anchors scroll position

### DIFF
--- a/lib/appsignal_markdown.rb
+++ b/lib/appsignal_markdown.rb
@@ -28,7 +28,7 @@ class AppsignalMarkdown < Middleman::Renderers::MiddlemanRedcarpetHTML
   # Create a link from the heading.
   def header(text, level)
     anchor = text.parameterize
-    %(<h%s id="%s"><a href="#%s">%s</a></h%s>) % [level, anchor, anchor, text, level]
+    %(<h%s><span class="anchor" id="%s"></span><a href="#%s">%s</a></h%s>) % [level, anchor, anchor, text, level]
   end
 
   private

--- a/source/stylesheets/modules/_article.css.sass
+++ b/source/stylesheets/modules/_article.css.sass
@@ -22,9 +22,17 @@
     @extend %h-tiny
 
   h1, h2, h3, h4
+    position: relative
+
     a
       color: $font-heading
       text-decoration: none
+
+    .anchor
+      position: absolute
+      top: -($header-height + 20px)
+      pointer-events: none
+      user-select: none
 
   p + h2
     margin-top: 40px

--- a/source/stylesheets/modules/_header.css.sass
+++ b/source/stylesheets/modules/_header.css.sass
@@ -4,7 +4,7 @@
   justify-content: space-between
   width: 100%
   top: 0
-  height: 60px
+  height: $header-height
   align-items: center
   z-index: 100
   background: $blue-dark

--- a/source/stylesheets/utilities/_variables.css.scss
+++ b/source/stylesheets/utilities/_variables.css.scss
@@ -1,6 +1,8 @@
 $alt-font: "myriad-pro", Helvetica, sans-serif;
 $icon-font: "FontAwesome";
 
+$header-height: 60px;
+
 $font-size: 14px;
 $font-size-large: 16px;
 $font-color: #19282d; //same as dark


### PR DESCRIPTION
Currently when you scroll down to an anchor, by clicking an anchor link,
the heading you scrolled down to is hidden by the top header bar. That's
because it has a fixed positioned of being at the top.

This change uses a separate element for the anchor, which is positioned
above the heading element, so that the header doesn't move over it and
hide the heading you just scrolled down to.

This PR is already put online, in case you're testing it there, but is here for review.

## Before

scrolling down to "Agent" on the terminology page you can't see the heading you just scrolled to.

![image](https://cloud.githubusercontent.com/assets/282402/22370048/a0450c20-e48f-11e6-93f4-bce79ba1ff37.png)

## After

scrolling down to "Agent" on the terminology page you can now see the heading

![image](https://cloud.githubusercontent.com/assets/282402/22370063/b69d0d6a-e48f-11e6-8017-c08a01b23e20.png)
