### PR TITLE
Update outdated text on Alpine Linux support

### DIFF
--- a/source/support/operating-systems.html.md
+++ b/source/support/operating-systems.html.md
@@ -10,7 +10,7 @@ most Linux distributions and macOS.
 
 ### Alpine Linux
 
-Alpine Linux support is currently in Alpha. You can try our experimental Alpine
+Alpine Linux support is currently in Alpha. You can try our Alpine
 Linux support by installing the `2.1.0.alpha.x` versions of the AppSignal gem.
 
 ```
@@ -18,16 +18,12 @@ gem "appsignal", "2.1.0.alpha.2"
 ```
 
 For the latest available alpha version see the full list on
-[Rubygems.org](https://rubygems.org/gems/appsignal/versions) and [track our
-progress here](https://github.com/appsignal/appsignal-ruby/pull/229).
-
-Alpine Linux support for our Elixir package is in the works. Track its progress
-on [this issue](https://github.com/appsignal/appsignal-elixir/issues/16).
+[Rubygems.org](https://rubygems.org/gems/appsignal/versions).
 
 Please [let us know](mailto:support@appsignal.com) if you run into any problems
 in our alpha version.
 
-Alpine Linux was originally not supported because our agent, which written in
+Alpine Linux was originally not supported because our agent, which is written in
 Rust, does not fully support Alpine Linux's musl C standard library yet. This
 has been reported upstream to the Rust team and they are working to improve
 support for Alpine Linux.

--- a/source/support/operating-systems.html.md
+++ b/source/support/operating-systems.html.md
@@ -10,26 +10,44 @@ most Linux distributions and macOS.
 
 ### Alpine Linux
 
-Alpine Linux support is currently in Alpha. You can try our Alpine
-Linux support by installing the `2.1.0.alpha.x` versions of the AppSignal gem.
-
-```
-gem "appsignal", "2.1.0.alpha.2"
-```
-
-For the latest available alpha version see the full list on
-[Rubygems.org](https://rubygems.org/gems/appsignal/versions).
-
-Please [let us know](mailto:support@appsignal.com) if you run into any problems
-in our alpha version.
+[Alpine Linux] support was added in version `2.1.0` of the AppSignal gem. Our
+Elixir package supports Alpine Linux since version `0.10.0`.
 
 Alpine Linux was originally not supported because our agent, which is written in
-Rust, does not fully support Alpine Linux's musl C standard library yet. This
-has been reported upstream to the Rust team and they are working to improve
+[Rust], does not fully support Alpine Linux's [musl] C standard library yet.
+This has been reported upstream to the Rust team and they are working to improve
 support for Alpine Linux.
+
+#### Ruby
+
+For the Ruby gem add this to your `Gemfile`:
+
+```ruby
+gem "appsignal", ">= 2.1.0" # or a newer version
+```
+
+For the latest available version see the full list on
+[RubyGems.org](https://rubygems.org/gems/appsignal/versions) and if you run
+into any problems please [let us know](mailto:support@appsignal.com).
+
+#### Elixir
+
+If you're using Elixir, add this to your `mix.exs` file:
+
+```elixir
+{:appsignal, ">= 1.0.0"} # or a newer version
+```
+
+For the latest available version see the full list on
+[Hex.pm](https://hex.pm/packages/appsignal) and if you run
+into any problems please [let us know](mailto:support@appsignal.com).
 
 ## Microsoft Windows
 
 We are undecided on supporting Windows. If you use Windows in your production
 environment and would like us to support it, [send us an
 e-mail](mailto:support@appsignal.com).
+
+[Alpine Linux]: https://alpinelinux.org/
+[musl]: https://www.musl-libc.org/
+[Rust]: https://www.rust-lang.org/en-US/


### PR DESCRIPTION
Alpine Linux has already been featured for both Ruby and Elixir. Text in docs was still about an experimental version and the issue mentioned has already been closed. 