### PR TITLE
Fix wrong prefix for http-requests

### DIFF
--- a/source/ruby/instrumentation/integrating-appsignal.html.md
+++ b/source/ruby/instrumentation/integrating-appsignal.html.md
@@ -66,7 +66,7 @@ end
 ```
 
 If the first argument starts with `perform_job` the transaction will be
-recognized as a background job, if it starts with `perform_action` it will be
+recognized as a background job, if it starts with `process_action` it will be
 recognized as an HTTP request.
 
 Before your process exits it's necessary to call `Appsignal.stop` to make sure


### PR DESCRIPTION
http-requests should start with `process_action` and not `perform_action`, see https://github.com/appsignal/appsignal-ruby/blob/master/lib/appsignal.rb#L109

