### PR TITLE
Mention ~> 1.0 in the Elixir install guide

### DIFF
--- a/source/elixir/installation.html.md
+++ b/source/elixir/installation.html.md
@@ -44,7 +44,7 @@ xcode-select --install
     ```elixir
     # mix.exs
     def deps do
-      [{:appsignal, "~> 0.0"}]
+      [{:appsignal, "~> 1.0"}]
     end
     ```
 


### PR DESCRIPTION
... instead of ~> 0.0 