### PR TITLE
Describe instrumenting custom plugs

### DIFF
--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -139,6 +139,57 @@ defmodule SomeApp.MyChannel do
 end
 ```
 
+## Instrumentation for Plugs
+
+Exceptions in Plugs are automatically caught by AppSignal, but performance samples need to be set up manually using the custom instrumentation helpers or decorators.
+
+### Plug instrumentation with decorators
+
+To add instrumentation to plugs, use the `Appsignal.Instrumentation.Decorators` module, and decorate your Plug's `call/2` function using the `transaction_event/0-1` function.
+
+``` elixir
+defmodule SlowPlugWithDecorators do
+  import Plug.Conn
+  # use Appsignal's decorators
+  use Appsignal.Instrumentation.Decorators
+
+  def init(opts), do: opts
+
+  # Decorate the call/2 function to add custom instrumentation
+  @decorate transaction_event()
+  def call(conn, _) do
+    :timer.sleep(1000)
+    conn
+  end
+end
+```
+
+See the [`transaction_event`](https://docs.appsignal.com/elixir/instrumentation/instrumentation.html#decorator-transaction-events) documentation for more information.
+
+### Plug instrumentation without decorators
+
+Instead of using the decorators, you can use the `instrument/3` method to decorate a block of code directly.
+
+``` elixir
+defmodule SlowPlugWithInstrumentationHelpers do
+  import Plug.Conn
+  # Import the instrument-function
+  import Appsignal.Instrumentation.Helpers, only: [instrument: 3]
+
+  def init(opts), do: opts
+
+  def call(conn, _) do
+    # Wrap the contents of the call/2 function in an instrumentation block
+    instrument("timer.sleep", "Sleeping", fn() ->
+      :timer.sleep(1000)
+      conn
+    end)
+  end
+end
+```
+
+See the [instrumentation helpers](https://docs.appsignal.com/elixir/instrumentation/instrumentation.html#instrumentation-helper-functions) documentation for more information.
+
 ## Custom instrumentation
 
 [Add custom instrumentation](/elixir/instrumentation/instrumentation.html) to

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -22,6 +22,7 @@ documentation][hex-appsignal].
 - [Channels](#channels)
   - [Channels instrumentation with a channel's handle](#channel-instrumentation-with-a-channel-39-s-handle)
   - [Channels instrumentation without decorators](#channel-instrumentation-without-decorators)
+- [Instrumentation for custom Plugs](#instrumentation-for-included-plugs)
 - [Custom instrumentation](#custom-instrumentation)
 
 ## Incoming HTTP requests
@@ -139,56 +140,13 @@ defmodule SomeApp.MyChannel do
 end
 ```
 
-## Instrumentation for Plugs
+## Instrumentation for included Plugs
 
-Exceptions in Plugs are automatically caught by AppSignal, but performance samples need to be set up manually using the custom instrumentation helpers or decorators.
-
-### Plug instrumentation with decorators
-
-To add instrumentation to plugs, use the `Appsignal.Instrumentation.Decorators` module, and decorate your Plug's `call/2` function using the `transaction_event/0-1` function.
-
-``` elixir
-defmodule SlowPlugWithDecorators do
-  import Plug.Conn
-  # use Appsignal's decorators
-  use Appsignal.Instrumentation.Decorators
-
-  def init(opts), do: opts
-
-  # Decorate the call/2 function to add custom instrumentation
-  @decorate transaction_event()
-  def call(conn, _) do
-    :timer.sleep(1000)
-    conn
-  end
-end
-```
-
-See the [`transaction_event`](https://docs.appsignal.com/elixir/instrumentation/instrumentation.html#decorator-transaction-events) documentation for more information.
-
-### Plug instrumentation without decorators
-
-Instead of using the decorators, you can use the `instrument/3` method to decorate a block of code directly.
-
-``` elixir
-defmodule SlowPlugWithInstrumentationHelpers do
-  import Plug.Conn
-  # Import the instrument-function
-  import Appsignal.Instrumentation.Helpers, only: [instrument: 3]
-
-  def init(opts), do: opts
-
-  def call(conn, _) do
-    # Wrap the contents of the call/2 function in an instrumentation block
-    instrument("timer.sleep", "Sleeping", fn() ->
-      :timer.sleep(1000)
-      conn
-    end)
-  end
-end
-```
-
-See the [instrumentation helpers](https://docs.appsignal.com/elixir/instrumentation/instrumentation.html#instrumentation-helper-functions) documentation for more information.
+Exceptions in included Plugs are automatically caught by AppSignal, but
+performance samples need to be set up manually using the custom instrumentation
+helpers or decorators. See the
+[Plug](/elixir/integrations/plug.html#instrumentation-for-included-plugs)
+documentation for more information.
 
 ## Custom instrumentation
 


### PR DESCRIPTION
Closes #143.

Note that custom Plugs (like Rack middleware) need to be instrumented manually to get events into the sample breakdown, and provide an example using the decorators as well as the instrumentation helpers (taken from https://github.com/jeffkreeftmeijer/appsignal-phoenix-example/commit/a2c6022ba67626282023f4fdfe848c586f60cbfb).