### PR TITLE
Add Discord to the integrations page

### DIFF
--- a/source/application/integrations/index.html.md
+++ b/source/application/integrations/index.html.md
@@ -20,6 +20,7 @@ To enable notifications and issue tracker integration for external services, go 
 - [Phabricator](#phabricator)
 - [Pivotal Tracker](#pivotal-tracker)
 - [Slack](#slack)
+- [Discord](#discord)
 - [Trello](#trello)
 - [Webhook](/application/integrations/webhooks.html)
 - [Zapier](#zapier)
@@ -95,6 +96,14 @@ Website: [http://www.pivotaltracker.com/](http://www.pivotaltracker.com/)
 Slack brings all your communication together in one place. It's real-time messaging, archiving and search for modern teams.
 
 Website: [https://www.slack.com](https://www.slack.com)
+
+## Discord
+
+All-in-one voice and text chat for gamers that's free, secure, and works on both your desktop and phone.
+
+We support Discord through their [Slack-compatible webhook](https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook). To enable it, [find your webhook URL](https://support.discordapp.com/hc/en-us/articles/228383668-Intro-to-Webhooks), append "/slack" to it, and use it as the webhook URL in our Slack integration.
+
+Website: [https://discordapp.com](https://discordapp.com)
 
 ## Trello
 

--- a/source/application/integrations/index.html.md
+++ b/source/application/integrations/index.html.md
@@ -29,7 +29,7 @@ To enable notifications and issue tracker integration for external services, go 
 
 All-in-one voice and text chat for gamers that's free, secure, and works on both your desktop and phone.
 
-We support Discord through their [Slack-compatible webhook](https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook). To enable it, [find your webhook URL](https://support.discordapp.com/hc/en-us/articles/228383668-Intro-to-Webhooks), append "/slack" to it, and use it as the webhook URL in our Slack integration.
+We support Discord through their [Slack-compatible webhook](https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook). To enable it, [find your webhook URL](https://support.discordapp.com/hc/en-us/articles/228383668-Intro-to-Webhooks), append `/slack` to it, and use it as the webhook URL in our [Slack](#slack) integration.
 
 Website: [https://discordapp.com](https://discordapp.com)
 

--- a/source/application/integrations/index.html.md
+++ b/source/application/integrations/index.html.md
@@ -8,6 +8,7 @@ To enable notifications and issue tracker integration for external services, go 
 
 ## Available integrations
 
+- [Discord](#discord)
 - [Flowdock](#flowdock)
 - [Geckoboard](#geckoboard)
 - [GitHub](#github)
@@ -20,10 +21,17 @@ To enable notifications and issue tracker integration for external services, go 
 - [Phabricator](#phabricator)
 - [Pivotal Tracker](#pivotal-tracker)
 - [Slack](#slack)
-- [Discord](#discord)
 - [Trello](#trello)
 - [Webhook](/application/integrations/webhooks.html)
 - [Zapier](#zapier)
+
+## Discord
+
+All-in-one voice and text chat for gamers that's free, secure, and works on both your desktop and phone.
+
+We support Discord through their [Slack-compatible webhook](https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook). To enable it, [find your webhook URL](https://support.discordapp.com/hc/en-us/articles/228383668-Intro-to-Webhooks), append "/slack" to it, and use it as the webhook URL in our Slack integration.
+
+Website: [https://discordapp.com](https://discordapp.com)
 
 ## Flowdock
 
@@ -96,14 +104,6 @@ Website: [http://www.pivotaltracker.com/](http://www.pivotaltracker.com/)
 Slack brings all your communication together in one place. It's real-time messaging, archiving and search for modern teams.
 
 Website: [https://www.slack.com](https://www.slack.com)
-
-## Discord
-
-All-in-one voice and text chat for gamers that's free, secure, and works on both your desktop and phone.
-
-We support Discord through their [Slack-compatible webhook](https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook). To enable it, [find your webhook URL](https://support.discordapp.com/hc/en-us/articles/228383668-Intro-to-Webhooks), append "/slack" to it, and use it as the webhook URL in our Slack integration.
-
-Website: [https://discordapp.com](https://discordapp.com)
 
 ## Trello
 


### PR DESCRIPTION
We can use Discord's Slack-compatible webhooks, as found in https://github.com/appsignal/appsignal-server/issues/2998 (private repo).