### PR TITLE
Add paragraph on skipping session data

### DIFF
--- a/source/elixir/configuration/parameter-filtering.html.md
+++ b/source/elixir/configuration/parameter-filtering.html.md
@@ -32,3 +32,14 @@ AppSignal configuration file.
 config :appsignal, :config,
   filter_parameters: ["password", "secret"]
 ```
+
+## Skip sending session data
+
+If you don't want to send your session data to AppSignal you can add this to the
+AppSignal configuration file:
+
+```elixir
+# config/config.exs
+config :appsignal, :config,
+  skip_session_data: true
+```


### PR DESCRIPTION
This keeps it in line with the Ruby docs which also mentions the option on the _parameter filtering_ page.