### PR TITLE
Add cookie bar for docs

### DIFF
--- a/source/_cookies.html.haml
+++ b/source/_cookies.html.haml
@@ -1,0 +1,3 @@
+.mod-cookies
+  %p We'd like to set cookies, #{link_to "read why", "https://appsignal.com/privacy-policy"}.
+  %button.button.tiny.accept_link I accept

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -54,7 +54,7 @@ $(document).ready(function() {
     $(".logged-out").hide();
   }
 
-  if (Cookies.get("appsignal_cookie_consent") == "true") {
+  if (Cookies.get("cookie_consent") == "true") {
     $(".mod-cookies").hide();
   }
 

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -54,6 +54,10 @@ $(document).ready(function() {
     $(".logged-out").hide();
   }
 
+  if (Cookies.get("appsignal_cookie_consent") == "true") {
+    $(".mod-cookies").hide();
+  }
+
   // Track pageview
   if (window.location.host == "docs.appsignal.com") {
     var tracker_src = "https://appsignal.com/ident.gif?page=" +
@@ -67,4 +71,17 @@ $(document).ready(function() {
     img.style = "display:none;";
     document.body.appendChild(img);
   }
+
+  $(".mod-cookies .accept_link").click(function(e) {
+    e.preventDefault();
+    $(".mod-cookies").hide();
+
+    var consent_src = "https://appsignal.com/cookie_consent.gif";
+    var img = document.createElement("img");
+    img.src = consent_src;
+    img.height = "1";
+    img.width = "1";
+    img.style = "display:none;";
+    document.body.appendChild(img);
+  })
 });

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -65,6 +65,7 @@
         = partial 'side_nav'
       .layout-footer
         = partial 'footer'
+      = partial 'cookies'
 
   <script src="https://use.typekit.net/sdq1pbx.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>


### PR DESCRIPTION
Same as https://github.com/appsignal/appsignal-server/pull/3214, but for docs

## Todo
- [x] Hide on click with javascript
- [x] Set cookie so people won't see it next time