### PR TITLE
Add page about GDPR and fix warnings

### DIFF
--- a/source/_side_nav.html.haml
+++ b/source/_side_nav.html.haml
@@ -205,6 +205,7 @@
       %ul
         %li= link_with_active 'Contributing', '/appsignal/contributing.html'
         %li= link_with_active 'Security', '/appsignal/security.html'
+        %li= link_with_active 'GDPR', '/appsignal/gdpr.html'
         %li= link_with_active 'How AppSignal operates', '/appsignal/how-appsignal-operates.html'
         %li= link_with_active 'Life cycle of an AppSignal request', '/appsignal/request-lifecycle.html'
         %li= link_with_active 'Terminology', '/appsignal/terminology.html'

--- a/source/appsignal/gdpr.html.md
+++ b/source/appsignal/gdpr.html.md
@@ -26,13 +26,13 @@ When sharing data with vendors, we have made sure there are contracts in place t
 
 ### Data Processor
 
-Our customers are the Data Controllers for the data that their applications gather and send to AppSignal. AppSignal processes that data on behalf of them, which makes it the Data Processor. To enable our customers to be fully GDPR compliant while using AppSignal, we have taken various measures.
+Our customers are the Data Controllers for the data that their applications gather and send to AppSignal. AppSignal processes that data on behalf of them, which makes us the Data Processor. To enable our customers to be fully GDPR compliant while using AppSignal, we have taken various measures.
 
 In short: AppSignal doesn't wish to receive any personal data about your visitors, and will provide the tools that enable you to strip this information before sending it to AppSignal for processing. For more details, see below.
 
 #### Data Processing Agreement
 
-We have created a Data Processing Agreement that explains that eg. how we are a Data Processor, how we limit processing to the level needed to be able to provide the AppSignal service, that we will ensure that our vendors are compliant too, etc (this is an incomplete list for illustrative purposes only; please see the full Data Processing Agreement for all the details).
+We have created a Data Processing Agreement that explains eg. how we are a Data Processor, how we limit processing to the level needed to be able to provide the AppSignal service, that we will ensure that our vendors are compliant too, etc (this is an incomplete list for illustrative purposes only; please see the full Data Processing Agreement for all the details).
 
 The Data Processing Agreement is accessible to all owners for an organization on AppSignal. You can find it by going to your "[Profile & Settings](https://appsignal.com/users/edit)" and look for the agreement in the left navigation (there is one for each organization). You can digitally sign the Data Processing Agreement, and once signed we will display who signed it and when.
 

--- a/source/appsignal/gdpr.html.md
+++ b/source/appsignal/gdpr.html.md
@@ -46,7 +46,9 @@ Any non-whitelisted headers are stripped before being sent to AppSignal.
 
 #### Filtering options for parameters and session data
 
-We have had filtering options for _parameters_ for a long time already, but in our documentation ([Ruby](/ruby/configuration/parameter-filtering.html) / [Elixir](/elixir/configuration/parameter-filtering.html)) we now stress the importance with regard to GDPR. Our filtering options allow customers to send parameters or session data to AppSignal without exposing personal data, by replacing that data with `[FILTERED]`. Alternatively, a customer can choose to not send any parameters at all.
+We've had filtering options for _parameters_ for a long time already, but in our documentation ([Ruby](https://docs.appsignal.com/ruby/configuration/parameter-filtering.html) / [Elixir](https://docs.appsignal.com/elixir/configuration/parameter-filtering.html)) we now stress the importance with regard to GDPR.
+
+The latest Ruby gem and Elixir package releases expand this filtering feature to session data too. It allows customers to send parameters to AppSignal without exposing personal data, by replacing that data with `[FILTERED]`. Alternatively, a customer can choose to not send any parameters or session data at all.
 
 Data is filtered before being sent to AppSignal.
 

--- a/source/appsignal/gdpr.html.md
+++ b/source/appsignal/gdpr.html.md
@@ -46,9 +46,7 @@ Any non-whitelisted headers are stripped before being sent to AppSignal.
 
 #### Filtering options for parameters and session data
 
-We have had filtering options for _parameters_ for a long time already, but in our documentation ([Ruby](/ruby/configuration/parameter-filtering.html) / [Elixir](/elixir/configuration/parameter-filtering.html)) now stress the importance with regard to GDPR. This feature allows customers to send parameters to AppSignal without exposing personal data, by replacing that data with `[FILTERED]`. Alternatively, a customer can choose to not send and parameters at all.
-
-We're working extending these filtering capabilities to _session data_, but for now the sending of session data should be skipped if it may contain personal data.
+We have had filtering options for _parameters_ for a long time already, but in our documentation ([Ruby](/ruby/configuration/parameter-filtering.html) / [Elixir](/elixir/configuration/parameter-filtering.html)) we now stress the importance with regard to GDPR. Our filtering options allow customers to send parameters or session data to AppSignal without exposing personal data, by replacing that data with `[FILTERED]`. Alternatively, a customer can choose to not send any parameters at all.
 
 Data is filtered before being sent to AppSignal.
 

--- a/source/appsignal/gdpr.html.md
+++ b/source/appsignal/gdpr.html.md
@@ -20,9 +20,11 @@ In relation to our customers, AppSignal is both a Data Controller and a Data Pro
 
 ### Data Controller
 
-AppSignal is the Data Controller for the information we collect about our customers, which means that we determine the "purposes and means" of the data we collect as the Controller. Some examples: their name, their email address, their credit card number, and any other data that we collect based on the GDPR legal bases. This data is safeguarded by various policies and procedures.
+AppSignal is the Data Controller for the information we collect about our customers and visitors, which means that we determine the "purposes and means" of the data we collect as the Controller. Some examples: their name, their email address, their credit card number, and any other data that we collect based on the GDPR legal bases. This data is safeguarded by various policies and procedures.
 
 When sharing data with vendors, we have made sure there are contracts in place that ensure they also receive and process this data in a lawful way.
+
+You can read more about the data we collect for which purpose in our new [Privacy Policy](https://appsignal.com/privacy-policy).
 
 ### Data Processor
 

--- a/source/appsignal/gdpr.html.md
+++ b/source/appsignal/gdpr.html.md
@@ -1,0 +1,61 @@
+---
+title: "General Data Protection Regulation (GDPR)"
+---
+
+AppSignal has always had a strong focus on protecting any data we collect and process. As a European owned and operated business we appreciate the solidification of this through the General Data Protection Regulation (GDPR) laws that enter into effect on May 25, 2018.
+
+Below you'll read how GDPR applies to AppSignal, our customers and the people our customers collect data from.
+
+## Compliance in relation to our employees and vendors
+
+AppSignal B.V. is the entity that owns and operates the AppSignal service, a business located in the Netherlands and therefor bound by Dutch and European law. This entity is fully GDPR compliant, which means we only request and process data based on legal bases as defined in the GDPR. In cooperation with our counsel we have made a thorough assessment of all of our processes and data stores.
+
+Where needed, we changed our internal policies and procedures to be in compliance with GDPR, and deleted data that we didn't need or want. We also defined a new Privacy Policy and wrote a Data Processing Agreement (more on that below).
+
+Finally, we reached out to our vendors to request agreements to ensure that we remain compliant when using their services.
+
+## Compliance in relation to our customers
+
+In relation to our customers, AppSignal is both a Data Controller and a Data Processor depending on the type of data collected.
+
+### Data Controller
+
+AppSignal is the Data Controller for the information we collect about our customers, which means that we determine the "purposes and means" of the data we collect as the Controller. Some examples: their name, their email address, their credit card number, and any other data that we collect based on the GDPR legal bases. This data is safeguarded by various policies and procedures.
+
+When sharing data with vendors, we have made sure there are contracts in place that ensure they also receive and process this data in a lawful way.
+
+### Data Processor
+
+Our customers are the Data Controllers for the data that their applications gather and send to AppSignal. AppSignal processes that data on behalf of them, which makes it the Data Processor. To enable our customers to be fully GDPR compliant while using AppSignal, we have taken various measures.
+
+In short: AppSignal doesn't wish to receive any personal data about your visitors, and will provide the tools that enable you to strip this information before sending it to AppSignal for processing. For more details, see below.
+
+#### Data Processing Agreement
+
+We have created a Data Processing Agreement that explains that eg. how we are a Data Processor, how we limit processing to the level needed to be able to provide the AppSignal service, that we will ensure that our vendors are compliant too, etc (this is an incomplete list for illustrative purposes only; please see the full Data Processing Agreement for all the details).
+
+The Data Processing Agreement is accessible to all owners for an organization on AppSignal. You can find it by going to your "[Profile & Settings](https://appsignal.com/users/edit)" and look for the agreement in the left navigation (there is one for each organization). You can digitally sign the Data Processing Agreement, and once signed we will display who signed it and when.
+
+#### Whitelisted request headers only
+
+We have always made sure to strip any personal data from incoming events such as database queries, but we did store request headers such as `REMOTE_ADDR`. Depending on architecture, this can expose useful information about load balancers or internal IP addresses. In most cases though, this sent visitor IP addresses to AppSignal. Since IP addresses are personal data, we have created a whitelist of headers that we believe will not contain personal data. Customers can add additional headers to the whitelist as needed, as long a they don't identify an individual (eg. if `REMOTE_ADDR` contains the IP address of a load balancer, that's fine).
+
+Any non-whitelisted headers are stripped before being sent to AppSignal.
+
+#### Filtering options for parameters and session data
+
+We have had filtering options for _parameters_ for a long time already, but in our documentation ([Ruby](/ruby/configuration/parameter-filtering.html) / [Elixir](/elixir/configuration/parameter-filtering.html)) now stress the importance with regard to GDPR. This feature allows customers to send parameters to AppSignal without exposing personal data, by replacing that data with `[FILTERED]`. Alternatively, a customer can choose to not send and parameters at all.
+
+We're working extending these filtering capabilities to _session data_, but for now the sending of session data should be skipped if it may contain personal data.
+
+Data is filtered before being sent to AppSignal.
+
+#### Requirements for Tagging
+
+We have changed the documentation for our Tagging feature ([Ruby](/ruby/instrumentation/tagging.html) / [Elixir](/elixir/instrumentation/tagging.html)) to strongly state that no personal data should be sent to AppSignal in tags, and that user IDs, hashes or pseudonymized identifiers should be used instead.
+
+#### Data removal procedure
+
+Any details about a request are stored within what we call "samples". These samples have a retention of 30, 45 or 60 days depending on plan. This has always been the case, but is important with regard to GDPR as well. It means that if any personal data was collected accidentally, it will still be purged after a maximum of 60 days. After that, we only keep aggregated data.
+
+If a customer notices that personal data was accidentally sent as part of a sample, we have instated a procedure that allows us to remove one or more samples when requested in an email to support@appsignal.com.

--- a/source/elixir/instrumentation/tagging.html.md
+++ b/source/elixir/instrumentation/tagging.html.md
@@ -10,6 +10,12 @@ the request, session or environment parameters.
 Appsignal.Transaction.set_sample_data("tags", %{locale: "en"})
 ```
 
+!> **Warning**: Do not use tagging to send personal data such as names or email
+   addresses to AppSignal. If you want to identify a person, consider using a
+   user ID, hash or pseudonymized identifier instead. You can use
+   [link templates](/application/link-templates.html) to link them to your own
+   system.
+
 ## Tags
 
 Using tags you can easily add more information to errors and performance issues
@@ -35,12 +41,6 @@ will result in the following data:
   locale: "de"
 }
 ```
-
-!> **Note**: Do not use tagging to send personal data such as names or email
-   addresses to AppSignal. If you want to identify a person, consider using a
-   user ID, hash or pseudonymized identifier instead. You can use
-   [link templates](/application/link-templates.html) to link them to your own
-   system.
 
 ## Link templates
 

--- a/source/ruby/configuration/parameter-filtering.html.md
+++ b/source/ruby/configuration/parameter-filtering.html.md
@@ -97,3 +97,8 @@ To filter all parameters without individual parameter filtering, set [`send_para
 production:
   send_params: false
 ```
+
+!> **Note**: Do not send personal data to AppSignal. If your parameters contain
+   personal data, please use filtering. If your session data contains personal
+   data, please skip sending it to AppSignal _until we add filtering to session
+   data too (soon!)_.

--- a/source/ruby/instrumentation/tagging.html.md
+++ b/source/ruby/instrumentation/tagging.html.md
@@ -16,6 +16,12 @@ Appsignal.tag_request(
 )
 ```
 
+!> **Warning**: Do not use tagging to send personal data such as names or email
+   addresses to AppSignal. If you want to identify a person, consider using a
+   user ID, hash or pseudonymized identifier instead. You can use
+   [link templates](/application/link-templates.html) to link them to your own
+   system.
+
 ## Tags
 
 Using tags you can easily add more information to errors and performance issues
@@ -43,12 +49,6 @@ Appsignal.tag_request(
   }
 )
 ```
-
-!> **Note**: Do not use tagging to send personal data such as names or email
-   addresses to AppSignal. If you want to identify a person, consider using a
-   user ID, hash or pseudonymized identifier instead. You can use
-   [link templates](/application/link-templates.html) to link them to your own
-   system.
 
 ## Link templates
 


### PR DESCRIPTION
This PR adds a page to the docs to explain how AppSignal complies with GDPR, and how our customers can be compliant while using AppSignal. It also changes a note on tagging (for both Ruby and Elixir) into a warning to stress its importance with regard to GDPR.