### PR TITLE
Add a note on not supporting path symbols

### DIFF
--- a/source/elixir/configuration/options.html.md.erb
+++ b/source/elixir/configuration/options.html.md.erb
@@ -39,6 +39,8 @@ Configure the path of the SSL certificate file on your machine. Default is
 `nil` and will use the system default certificate files. Use this option to
 point to another certificate file if there's a problem connecting to our API.
 
+<%= partial "shared/file_paths" %>
+
 ## `APPSIGNAL_DEBUG` / `:debug`
 
 - Value: `true`/`false`. Default: `false`
@@ -177,8 +179,9 @@ Select which logger to the AppSignal agent should use. Accepted values are
 
 - Value: String. Default: `/tmp/appsignal.log`
 
-Override the location of the path where the AppSignal log file will be written
-to.
+Override the location of the path where the AppSignal log file will be written to.
+
+<%= partial "shared/file_paths" %>
 
 ## `APPSIGNAL_PUSH_API_ENDPOINT` / `:endpoint`
 
@@ -247,6 +250,8 @@ samples.
 
 Override the location where AppSignal for Elixir creates a working directory.
 
+<%= partial "shared/file_paths" %>
+
 ## `APPSIGNAL_WORKING_DIRECTORY_PATH` / `:working_directory_path`
 
 - Available since package version `1.8.0`. (Please use the [`working_dir_path`](#appsignal_working_dir_path-working_dir_path) option on earlier versions.)
@@ -261,6 +266,8 @@ If you are running multiple applications using AppSignal on the same server, use
 config :appsignal, :config,
   working_dir_path: "/tmp/project_1/"
 ```
+
+<%= partial "shared/file_paths" %>
 
 ## `APP_REVISION` / `:revision`
 

--- a/source/ruby/configuration/options.html.md.erb
+++ b/source/ruby/configuration/options.html.md.erb
@@ -49,6 +49,8 @@ file](https://github.com/appsignal/appsignal-ruby/blob/4eed259e122d10df66655098a
 in the gem itself. Use this option to point to another certificate file if
 there's a problem connecting to our API.
 
+<%= partial "shared/file_paths" %>
+
 ## `APPSIGNAL_DEBUG` / `:debug`
 
 - Available since gem version `1.0.0`.
@@ -111,6 +113,8 @@ Select which logger to the AppSignal agent should use. Accepted values are
 
 Override the location of the path where the appsignal log file can be written
 to.
+
+<%= partial "shared/file_paths" %>
 
 ## `APPSIGNAL_ENABLE_ALLOCATION_TRACKING` / `:enable_allocation_tracking`
 
@@ -356,9 +360,11 @@ samples.
 
 Override the location where AppSignal for Ruby creates a working directory. See [`working_directory_path`](#appsignal_working_directory_path-working_directory_path) for the behavior it is applicable. This config option appends `/appsignal` to the specified path, where [`working_directory_path`](#appsignal_working_directory_path-working_directory_path) does not.
 
+<%= partial "shared/file_paths" %>
+
 ## `APPSIGNAL_WORKING_DIRECTORY_PATH` / `:working_directory_path`
 
-- Available since gem version `2.8.0`. (Please use the [`working_dir_path`](#appsignal_working_dir_path-working_dir_path) option on earlier versions.)
+- Available since gem version `2.7.0`. (Please use the [`working_dir_path`](#appsignal_working_dir_path-working_dir_path) option on earlier versions.)
 - Value: String. Default: detected by agent
 
 Override the location where AppSignal for Ruby can store temporary files. Use this option if the default location is not suitable. See our [how AppSignal operates](/appsignal/how-appsignal-operates.html) page for more information about the purpose of this working directory.
@@ -370,6 +376,8 @@ If you are running multiple applications using AppSignal on the same server, use
 default: &defaults
   working_directory_path: "/tmp/project_1/"
 ```
+
+<%= partial "shared/file_paths" %>
 
 ## `APP_REVISION` / `:revision`
 

--- a/source/shared/_file_paths.md
+++ b/source/shared/_file_paths.md
@@ -1,0 +1,1 @@
+**Note**: The specified path cannot contain Operating Specific file system abstractions, such as the homedir symbol `~` for *NIX systems. This will be seen an malformed path.


### PR DESCRIPTION
Prevents confusion about common usage of the homedir symbol `~` and
other such symbols.