### PR TITLE
Fix typo in example code

### DIFF
--- a/source/ruby/integrations/rails.html.md
+++ b/source/ruby/integrations/rails.html.md
@@ -16,7 +16,7 @@ begin
   require ::File.expand_path("../config/environment",  __FILE__)
 rescue Exception => error
   Appsignal.send_error(error)
-  raise e
+  raise
 end
 ```
 


### PR DESCRIPTION
`e` isn't defined. You could replace it with `error` but bare raise is easier to read I think.

BTW, also, I think if you're going to use `rescue Exception => error` rather than `StandardError` -- then you should make a comment about what you're trying to catch in addition.