### PR TITLE
Add Code of Conduct to our docs

### DIFF
--- a/source/appsignal/code-of-conduct.html.md
+++ b/source/appsignal/code-of-conduct.html.md
@@ -1,5 +1,5 @@
 ---
-title: Contributor Covenant Code of Conduct
+title: Code of Conduct
 ---
 
 ## Our Pledge

--- a/source/appsignal/code-of-conduct.html.md
+++ b/source/appsignal/code-of-conduct.html.md
@@ -1,0 +1,79 @@
+---
+title: Contributor Covenant Code of Conduct
+---
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [contact@appsignal.com][coc-contact]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+[coc-contact]: mailto:contact@appsignal.com
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/source/appsignal/contributing.html.md
+++ b/source/appsignal/contributing.html.md
@@ -112,4 +112,4 @@ behavior to [contact@appsignal.com][coc-contact].
 [travis-appsignal]: https://travis-ci.org/appsignal
 [semver]: http://semver.org/
 [coc-contact]: mailto:contact@appsignal.com
-[coc]:/appsignal/code-of-conduct.html
+[coc]: /appsignal/code-of-conduct.html

--- a/source/appsignal/contributing.html.md
+++ b/source/appsignal/contributing.html.md
@@ -26,11 +26,11 @@ Our main projects include:
 Other projects we have open sourced, and are used internally by other projects,
 include:
 
-- [AppSignal Rust agent][appsignal-rust]  
+- [AppSignal Rust agent][appsignal-rust]
   Early stage proof of concept of AppSignal Rust integration.
-- [sql_lexer][sql_lexer]  
+- [sql_lexer][sql_lexer]
   Rust library to lex and sanitize SQL queries.
-- [probes.rs][probes-rs]  
+- [probes.rs][probes-rs]
   Rust library to read out system stats from a machine running Linux.
 
 ## Using git and GitHub
@@ -89,6 +89,12 @@ If you think you've found a security issue with regards to our application,
 network or integrations, please let us know immediately by sending an email to
 [security@appsignal.com](mailto:security@appsignal.com).
 
+## Code of Conduct
+
+Everyone interacting in AppSignal's codebases and issue trackers is expected
+to follow the contributor [code of conduct][coc]. Please report unacceptable
+behavior to [contact@appsignal.com][coc-contact].
+
 [contact]: mailto:support@appsignal.com
 [blog]: http://blog.appsignal.com/
 [changelog]: https://appsignal.com/changelog
@@ -105,3 +111,5 @@ network or integrations, please let us know immediately by sending an email to
 [github-appsignal]: https://github.com/appsignal
 [travis-appsignal]: https://travis-ci.org/appsignal
 [semver]: http://semver.org/
+[coc-contact]: mailto:contact@appsignal.com
+[coc]:/appsignal/code-of-conduct.html

--- a/source/appsignal/contributing.html.md
+++ b/source/appsignal/contributing.html.md
@@ -26,11 +26,11 @@ Our main projects include:
 Other projects we have open sourced, and are used internally by other projects,
 include:
 
-- [AppSignal Rust agent][appsignal-rust]
+- [AppSignal Rust agent][appsignal-rust]  
   Early stage proof of concept of AppSignal Rust integration.
-- [sql_lexer][sql_lexer]
+- [sql_lexer][sql_lexer]  
   Rust library to lex and sanitize SQL queries.
-- [probes.rs][probes-rs]
+- [probes.rs][probes-rs]  
   Rust library to read out system stats from a machine running Linux.
 
 ## Using git and GitHub


### PR DESCRIPTION
This adds the CoC in a central place that will allow us to link to it
from all our public repo's.