### PR TITLE
Add note to explain that argument needs to be uniq

### DIFF
--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -107,8 +107,7 @@ Telemetry.attach(
 )
 ```
 
--> **Note**: If you're running an umbrella app, the first argument for
-`attach` needs to be an unique name withing the umbrella app.
+-> **Note**: Telemetry's handler ID (the first argument to the :telemetry.attach/4 function) needs to be unique across your application. Make sure to use unique IDs when attaching the Ecto integration to multiple Repos.
 
 On Ecto 2, add the `Appsignal.Ecto` module to your Repo's logger configuration instead. The `Ecto.LogEntry` logger is the default logger for Ecto and needs to be set as well to keep the original Ecto logger behavior intact.
 

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -107,7 +107,7 @@ Telemetry.attach(
 )
 ```
 
--> **Note**: Telemetry's handler ID (the first argument to the :telemetry.attach/4 function) needs to be unique across your application. Make sure to use unique IDs when attaching the Ecto integration to multiple Repos.
+-> **Note**: Telemetry's handler ID (the first argument to the `:telemetry.attach/4` function) needs to be unique across your application. Make sure to use unique IDs when attaching the Ecto integration to multiple Repos.
 
 On Ecto 2, add the `Appsignal.Ecto` module to your Repo's logger configuration instead. The `Ecto.LogEntry` logger is the default logger for Ecto and needs to be set as well to keep the original Ecto logger behavior intact.
 

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -107,6 +107,9 @@ Telemetry.attach(
 )
 ```
 
+-> **Note**: If you're running an umbrella app, the first argument for
+`attach` needs to be an unique name withing the umbrella app.
+
 On Ecto 2, add the `Appsignal.Ecto` module to your Repo's logger configuration instead. The `Ecto.LogEntry` logger is the default logger for Ecto and needs to be set as well to keep the original Ecto logger behavior intact.
 
 ```elixir


### PR DESCRIPTION
The first argument for attach needs to be uniq within an umbrella app.
If this is not the case Telemetry will not gather any information for
that app.