### PR TITLE
Add search to docs

### DIFF
--- a/source/_docsearch.html.haml
+++ b/source/_docsearch.html.haml
@@ -1,0 +1,2 @@
+.mod-docsearch
+  %input#search{:placeholder => "search docs"}

--- a/source/_header.html.haml
+++ b/source/_header.html.haml
@@ -8,6 +8,7 @@
       Menu
       %i.fa.fa-fw.fa-navicon
 
+    %input#search
     %nav.main
       %ul
         %li

--- a/source/_header.html.haml
+++ b/source/_header.html.haml
@@ -8,7 +8,6 @@
       Menu
       %i.fa.fa-fw.fa-navicon
 
-    %input#search
     %nav.main
       %ul
         %li

--- a/source/_side_nav.html.haml
+++ b/source/_side_nav.html.haml
@@ -1,18 +1,17 @@
 %nav.mod-side_nav
   %ul
-    %li.section
-      %ul
-        %li
-          %h2
-            = link_with_active "/" do
-              %i.fa.fa-home
-              Start
-          %h2
-            = link_with_active "/faq.html" do
-              %i.fa.fa-question
-              FAQs
+    %li
+      %h2
+        = link_with_active "/" do
+          %i.fa.fa-home
+          Start
+    %li
+      %h2
+        = link_with_active "/faq.html" do
+          %i.fa.fa-question
+          FAQs
 
-    %li.section
+    %li
       %h2{:data => { :menu => "getting-started" } }
         %i.fa.fa-fw.fa-angle-right
         Getting started
@@ -20,7 +19,7 @@
         %li= link_with_active "Your first application", "/getting-started/new-application.html"
         %li= link_with_active "Your user account", "/getting-started/user-account.html"
 
-    %li.section
+    %li
       %h2{:data => { :menu => "application" } }
         %i.fa.fa-fw.fa-angle-right
         Your applications
@@ -45,7 +44,7 @@
             %li= link_with_active "PagerDuty", "/application/integrations/pagerduty.html"
             %li= link_with_active "Webhooks", "/application/integrations/webhooks.html"
 
-    %li.section
+    %li
       %h2{:data => { :menu => "organization" } }
         %i.fa.fa-fw.fa-angle-right
         Your organizations
@@ -59,15 +58,15 @@
             %li= link_with_active "Manage teams", "/organization/team/teams.html"
         %li= link_with_active "Billing", "/organization/billing.html"
 
-    %li.section
+    %li.space-bottom
       %h2{:data => { :menu => "account" } }
         %i.fa.fa-fw.fa-angle-right
         Your user account
       %ul
         %li= link_with_active "Email addresses", "/user-account/email-addresses.html"
         %li= link_with_active "Two-factor authentication", "/user-account/two-factor-authentication.html"
-
-    %li.section
+  %ul
+    %li
       %h2{:data => { :menu => "ruby" } }
         %i.fa.fa-fw.fa-angle-right
         AppSignal for Ruby
@@ -127,7 +126,7 @@
             %li= link_with_active "Demo", "/ruby/command-line/demo.html"
             %li= link_with_active "Notify of Deploy", "/ruby/command-line/notify_of_deploy.html"
 
-    %li.section
+    %li
       %h2{:data => { :menu => "elixir" } }
         %i.fa.fa-fw.fa-angle-right
         AppSignal for Elixir
@@ -166,22 +165,22 @@
             %li= link_with_active "Demo", "/elixir/command-line/demo.html"
         %li= link_with_active "Why a NIF?", "/elixir/why-nif.html"
 
-    %li.section
+    %li
       %h2{:data => { :menu => "front-end" } }
         %i.fa.fa-fw.fa-angle-right
         AppSignal for Front-end <sup>Beta</sup>
       %ul
         %li= link_with_active "Front-end error catching", "/front-end/error-handling.html"
 
-    %li.section
+  %ul
+    %li
       %h2{:data => { :menu => "standalone-agent" } }
         %i.fa.fa-fw.fa-angle-right
         Standalone agent<sup>Beta</sup>
       %ul
         %li= link_with_active "Installation", "/standalone-agent/installation.html"
         %li= link_with_active "StatsD", "/standalone-agent/statsd.html"
-
-    %li.section
+    %li
       %h2{:data => { :menu => "metrics" } }
         %i.fa.fa-fw.fa-angle-right
         Metrics
@@ -195,18 +194,7 @@
           %ul
             %li= link_with_active "Heroku host metrics", "/metrics/host-metrics/heroku.html"
 
-    %li.section
-      %h2{:data => { :menu => "support" } }
-        %i.fa.fa-fw.fa-angle-right
-        Support
-      %ul
-        %li= link_to "Contact us!", "mailto:support@appsignal.com"
-        %li= link_with_active "Debugging AppSignal", "/support/debugging.html"
-        %li= link_with_active "Supported Operating Systems", "/support/operating-systems.html"
-        %li= link_with_active "Known issues", "/support/known-issues.html", :parent_active => true
-        %li= link_to "Service status page", "https://status.appsignal.com"
-
-    %li.section
+    %li
       %h2{:data => { :menu => "api" } }
         %i.fa.fa-fw.fa-angle-right
         AppSignal API <sup>Beta</sup>
@@ -219,10 +207,22 @@
         %li= link_with_active "Samples", "/api/samples.html"
         %li= link_with_active "Event names", "/api/event-names.html"
 
-    %li.section
+  %ul
+    %li
+      %h2{:data => { :menu => "support" } }
+        %i.fa.fa-fw.fa-angle-right
+        Support
+      %ul
+        %li= link_to "Contact us!", "mailto:support@appsignal.com"
+        %li= link_with_active "Debugging AppSignal", "/support/debugging.html"
+        %li= link_with_active "Supported Operating Systems", "/support/operating-systems.html"
+        %li= link_with_active "Known issues", "/support/known-issues.html", :parent_active => true
+        %li= link_to "Service status page", "https://status.appsignal.com"
+
+    %li
       %h2{:data => { :menu => "appsignal" } }
         %i.fa.fa-fw.fa-angle-right
-        AppSignal <sup>Meta</sup>
+        About AppSignal
       %ul
         %li
           = link_with_active "Contributing", "/appsignal/contributing.html"

--- a/source/_side_nav.html.haml
+++ b/source/_side_nav.html.haml
@@ -1,19 +1,11 @@
 %nav.mod-side_nav
   %ul
     %li
-      %h2
-        = link_with_active "/" do
-          %i.fa.fa-home
-          Start
+      %h2= link_with_active "Start", "/"
     %li
-      %h2
-        = link_with_active "/faq.html" do
-          %i.fa.fa-question
-          FAQs
-
+      %h2= link_with_active "FAQs", "/faq.html"
     %li
       %h2{:data => { :menu => "getting-started" } }
-        %i.fa.fa-fw.fa-angle-right
         Getting started
       %ul
         %li= link_with_active "Your first application", "/getting-started/new-application.html"
@@ -21,7 +13,6 @@
 
     %li
       %h2{:data => { :menu => "application" } }
-        %i.fa.fa-fw.fa-angle-right
         Your applications
       %ul
         %li= link_with_active "Overview", "/application/"
@@ -46,7 +37,6 @@
 
     %li
       %h2{:data => { :menu => "organization" } }
-        %i.fa.fa-fw.fa-angle-right
         Your organizations
       %ul
         %li= link_with_active "Overview", "/organization/"
@@ -60,7 +50,6 @@
 
     %li.space-bottom
       %h2{:data => { :menu => "account" } }
-        %i.fa.fa-fw.fa-angle-right
         Your user account
       %ul
         %li= link_with_active "Email addresses", "/user-account/email-addresses.html"
@@ -68,7 +57,6 @@
   %ul
     %li
       %h2{:data => { :menu => "ruby" } }
-        %i.fa.fa-fw.fa-angle-right
         AppSignal for Ruby
       %ul
         %li= link_with_active "Overview", "/ruby/"
@@ -128,7 +116,6 @@
 
     %li
       %h2{:data => { :menu => "elixir" } }
-        %i.fa.fa-fw.fa-angle-right
         AppSignal for Elixir
       %ul
         %li= link_with_active "Overview", "/elixir/"
@@ -167,7 +154,6 @@
 
     %li
       %h2{:data => { :menu => "front-end" } }
-        %i.fa.fa-fw.fa-angle-right
         AppSignal for Front-end <sup>Beta</sup>
       %ul
         %li= link_with_active "Front-end error catching", "/front-end/error-handling.html"
@@ -175,14 +161,12 @@
   %ul
     %li
       %h2{:data => { :menu => "standalone-agent" } }
-        %i.fa.fa-fw.fa-angle-right
         Standalone agent<sup>Beta</sup>
       %ul
         %li= link_with_active "Installation", "/standalone-agent/installation.html"
         %li= link_with_active "StatsD", "/standalone-agent/statsd.html"
     %li
       %h2{:data => { :menu => "metrics" } }
-        %i.fa.fa-fw.fa-angle-right
         Metrics
       %ul
         %li
@@ -196,7 +180,6 @@
 
     %li
       %h2{:data => { :menu => "api" } }
-        %i.fa.fa-fw.fa-angle-right
         AppSignal API <sup>Beta</sup>
       %ul
         %li= link_with_active "Overview", "/api/"
@@ -210,7 +193,6 @@
   %ul
     %li
       %h2{:data => { :menu => "support" } }
-        %i.fa.fa-fw.fa-angle-right
         Support
       %ul
         %li= link_to "Contact us!", "mailto:support@appsignal.com"
@@ -221,7 +203,6 @@
 
     %li
       %h2{:data => { :menu => "appsignal" } }
-        %i.fa.fa-fw.fa-angle-right
         About AppSignal
       %ul
         %li

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -9,6 +9,7 @@
     %title= title
     = stylesheet_link_tag "application"
     = partial "analytics"
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
   %body
     = partial "header"

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -17,6 +17,8 @@
       %a.jump{href: "#navigation"}
         %i.fa.fa-book
         Docs navigation
+
+      = partial "docsearch"
       .layout-main#main
         .inner= yield
       .layout-side#navigation
@@ -26,3 +28,12 @@
       = partial "cookies"
 
     = javascript_include_tag "application", :async => :async
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript"> docsearch({
+    apiKey: 'e364f905db3f6b6dd982bbc0e22a6891',
+    indexName: 'appsignal',
+    inputSelector: '#search',
+    debug: false // Set debug to true if you want to inspect the dropdown
+    });
+    </script>
+>>>>>>> Add search to docs

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -28,12 +28,3 @@
       = partial "cookies"
 
     = javascript_include_tag "application", :async => :async
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-    <script type="text/javascript"> docsearch({
-    apiKey: 'e364f905db3f6b6dd982bbc0e22a6891',
-    indexName: 'appsignal',
-    inputSelector: '#search',
-    debug: false // Set debug to true if you want to inspect the dropdown
-    });
-    </script>
->>>>>>> Add search to docs

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -28,3 +28,11 @@
       = partial "cookies"
 
     = javascript_include_tag "application", :async => :async
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript"> docsearch({
+    apiKey: 'e364f905db3f6b6dd982bbc0e22a6891',
+    indexName: 'appsignal',
+    inputSelector: '#search',
+    debug: false // Set debug to true if you want to inspect the dropdown
+    });
+    </script>

--- a/source/stylesheets/application.css.sass
+++ b/source/stylesheets/application.css.sass
@@ -11,3 +11,4 @@
 @import "modules/article"
 @import "modules/footer"
 @import "modules/side_nav"
+@import "modules/docsearch"

--- a/source/stylesheets/base/_layout.sass
+++ b/source/stylesheets/base/_layout.sass
@@ -26,11 +26,11 @@ html
   +min-width($full)
     position: fixed
     left: 0
-    top: 80px
+    top: 140px
     width: $sidebar
     overflow-y: auto
     +scrollbar(7px, rgba($medium,.4))
-    height: calc(100vh - 80px)
+    height: calc(100vh - 140px)
 
 .layout-main
   +min-width($full)

--- a/source/stylesheets/base/_layout.sass
+++ b/source/stylesheets/base/_layout.sass
@@ -1,5 +1,5 @@
 $sidebar-small: 240px
-$sidebar: 320px
+$sidebar: 300px
 $full: 960px
 
 *

--- a/source/stylesheets/components/_jump.sass
+++ b/source/stylesheets/components/_jump.sass
@@ -13,5 +13,4 @@
     color: #fff
 
   +max-width($full)
-    margin-bottom: 30px
     display: block

--- a/source/stylesheets/modules/_docsearch.sass
+++ b/source/stylesheets/modules/_docsearch.sass
@@ -3,9 +3,10 @@
   background: $border
 
   +min-width($full)
-    position: absolute
+    position: fixed
     width: $sidebar
     z-index: 1000
+    height: 80px
 
   .algolia-autocomplete
     width: 100%
@@ -18,6 +19,8 @@
     +shadow
     +br
     padding: 10px
+    font-size: 14px
+    color: $medium
 
   input:focus
     outline: none
@@ -55,7 +58,7 @@
 
   /* Description description (eg. Bootstrap currently works...) */
   .algolia-autocomplete .algolia-docsearch-suggestion--text
-    font-size: 0.8rem
+    font-size: 0.9rem
     color: $medium
 
   /* Highlighted text */

--- a/source/stylesheets/modules/_docsearch.sass
+++ b/source/stylesheets/modules/_docsearch.sass
@@ -31,6 +31,13 @@
   .algolia-autocomplete
     font-size: 14px
 
+  +max-width(600px)
+    .algolia-autocomplete .ds-dropdown-menu
+      left: 0 !important
+      right: 0 !important
+      min-width: 100%
+      max-width: 100%
+
   /* Main category (eg. Getting Started) */
   .algolia-autocomplete .algolia-docsearch-suggestion--category-header
     color: $dark

--- a/source/stylesheets/modules/_docsearch.sass
+++ b/source/stylesheets/modules/_docsearch.sass
@@ -1,0 +1,64 @@
+.mod-docsearch
+  padding: 20px 30px
+  background: $border
+
+  +min-width($full)
+    position: absolute
+    width: $sidebar
+    z-index: 1000
+
+  .algolia-autocomplete
+    width: 100%
+
+    a
+      text-decoration: none
+
+  input
+    width: 100%
+    +shadow
+    +br
+    padding: 10px
+
+  input:focus
+    outline: none
+
+  input::placeholder
+    color: rgba($medium,0.7)
+
+  .algolia-autocomplete
+    font-size: 14px
+
+  /* Main category (eg. Getting Started) */
+  .algolia-autocomplete .algolia-docsearch-suggestion--category-header
+    color: $dark
+    font-weight: bold
+    padding-bottom: 10px
+    border-bottom: 1px solid $border-dark
+
+  .algolia-autocomplete .ds-suggestion
+    & + &
+      margin-bottom: 10px
+
+  /* Category (eg. Downloads) */
+  .algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column
+    color: rgba($medium,0.7)
+
+  .algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column:before,
+  .algolia-autocomplete .algolia-docsearch-suggestion--content:before
+    background: $border-dark
+
+  /* Title (eg. Bootstrap CDN) */
+  .algolia-autocomplete .algolia-docsearch-suggestion--title
+    font-weight: bold
+    color: $dark
+    margin-bottom: 0
+
+  /* Description description (eg. Bootstrap currently works...) */
+  .algolia-autocomplete .algolia-docsearch-suggestion--text
+    font-size: 0.8rem
+    color: $medium
+
+  /* Highlighted text */
+  .algolia-autocomplete .algolia-docsearch-suggestion--highlight
+    color: $blue
+    background: $light

--- a/source/stylesheets/modules/_side_nav.sass
+++ b/source/stylesheets/modules/_side_nav.sass
@@ -1,6 +1,5 @@
 .mod-side_nav
   padding: 30px 30px
-  margin-top: 40px
 
   > ul + ul
     padding-top: 10px
@@ -34,7 +33,7 @@
       transition: opacity 0.5s
       opacity: 0
       margin: 0 0 10px 10px
-      font-size: 0.8em
+      font-size: 0.9em
 
       ul
         padding-left: 15px

--- a/source/stylesheets/modules/_side_nav.sass
+++ b/source/stylesheets/modules/_side_nav.sass
@@ -16,15 +16,6 @@
     font-size: 14px
     position: relative
 
-    .fa
-      position: absolute
-      display: none
-      left: 0
-      top: 50%
-      transform: translateY(-50%)
-      opacity: 0.6
-      transition: transform 0.2s
-
     a
       color: inherit
 

--- a/source/stylesheets/modules/_side_nav.sass
+++ b/source/stylesheets/modules/_side_nav.sass
@@ -1,21 +1,29 @@
 .mod-side_nav
-  line-height: 2
-  padding: 50px 30px
+  padding: 30px 30px
+  margin-top: 40px
+
+  > ul + ul
+    padding-top: 10px
+    border-top: 1px solid $border-dark
+    margin-top: 10px
 
   h2
     cursor: pointer
-    +font-weight(bold)
-    padding: 15px 20px 15px 25px
-    line-height: 1
+    font-weight: bold
+    padding: 5px 0
     display: flex
     user-select: none
     color: $dark
+    font-size: 14px
+    position: relative
 
     .fa
       position: absolute
-      left: 25px
+      display: none
+      left: 0
+      top: 50%
+      transform: translateY(-50%)
       opacity: 0.6
-      margin-top: -1px
       transition: transform 0.2s
 
     a
@@ -25,7 +33,8 @@
       display: none
       transition: opacity 0.5s
       opacity: 0
-      margin: -5px 0 10px 25px
+      margin: 0 0 10px 10px
+      font-size: 0.8em
 
       ul
         padding-left: 15px
@@ -45,7 +54,8 @@
   h2[data-menu]
     &.open
       .fa
-        transform: rotate(90deg)
+        transform-origin: right
+        transform: translateZ(-50%) rotate(90deg)
 
   a,
   span
@@ -61,4 +71,4 @@
 
     &.active
       color: $blue
-      +font-weight(bold)
+      font-weight: bold


### PR DESCRIPTION
This adds the search field for the docs search. It doesn't have any styling. I discussed with @wesoudshoorn and he indicates that he has time to work on styling this next week.

**Todo**
- [x] Remove font-awesome icons + css from navigation
- [x] Responsiveness of search results

**Design changes**
- Removed icons from navigation
- Split up the navigation into sections for easier visual parsing of structure