### PR TITLE
Add docs for Elixir Minutely Probe

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -253,8 +253,14 @@ options:
         - "`2.9.0`: Default value was changed to `true`."
       type: bool
       default_value: true
-    description: |
-      Enables the [minutely probes](/ruby/instrumentation/minutely-probes.html) system.
+      description: |
+        Enables the [minutely probes](/ruby/instrumentation/minutely-probes.html) system.
+    elixir:
+      since: 1.10.1
+      type: bool
+      default_value: true
+      description: |
+        Enables the [minutely probes](/elixir/instrumentation/minutely-probes.html) system.
   - config_key: endpoint
     env_key: APPSIGNAL_PUSH_API_ENDPOINT
     ruby:

--- a/source/_side_nav.html.haml
+++ b/source/_side_nav.html.haml
@@ -154,7 +154,8 @@
             %li= link_with_active "Instrumentation", "/elixir/instrumentation/instrumentation.html"
             %li= link_with_active "Exception handling", "/elixir/instrumentation/exception-handling.html"
             %li= link_with_active "Tagging", "/elixir/instrumentation/tagging.html"
-            %Li= link_with_active "Namespaces", "/elixir/instrumentation/namespaces.html"
+            %li= link_with_active "Namespaces", "/elixir/instrumentation/namespaces.html"
+            %li= link_with_active "Minutely probes <sup>New</sup>", "/elixir/instrumentation/minutely-probes.html"
         %li
           = link_with_active "Command line tools", "/elixir/command-line/"
           %ul

--- a/source/elixir/instrumentation/minutely-probes.html.md
+++ b/source/elixir/instrumentation/minutely-probes.html.md
@@ -48,7 +48,7 @@ The minutely probes are configured using the [`enable_minutely_probes`](/elixir/
 ## Creating probes
 
 If you want to track more [custom metrics](/metrics/custom.html) from your app
-than our default proves do, you can add your own prove(s).
+than our default probes do, you can add your own probe(s).
 
 An AppSignal minutely probe can be an [Anonymous function](#anonymous-function), or a [Module based function](#module-based-function).
 

--- a/source/elixir/instrumentation/minutely-probes.html.md
+++ b/source/elixir/instrumentation/minutely-probes.html.md
@@ -1,0 +1,119 @@
+---
+title: "Minutely probes"
+---
+
+Minutely probes are a mechanism to periodically send custom metrics to AppSignal.
+This is a system that is included in the AppSignal Elixir package by default.
+At the start of every minute the minutely probes are triggered one by one to
+collect metrics and then snoozed until the next minute.
+
+By default the AppSignal Elixir gem enables a probe for the ErlangVM.
+
+-> **Note**: This feature is turned on by default in AppSignal Elixir package `1.10.1` and up.
+
+-> **Note**: We recommend using AppSignal Elixir package `1.10.1` and up when using this feature.
+
+## Table of Contents
+
+- [Usage](#usage)
+  - [Multiple instances](#multiple-instances)
+- [Configuration](#configuration)
+- [Creating probes](#creating-probes)
+  - [Anonymous function](#anonymous-function)
+  - [Module based function](#module-based-function)
+- [Registering probes](#registering-probes)
+- [Overriding default probes](#overriding-default-probes)
+
+## Usage
+
+The minutely probes allow the AppSignal Elixir package to collect [custom metrics](/metrics/custom.html)
+by default for the ErlangVM and app-specific metrics by [creating your own probe](#creating-probes).
+
+### Multiple instances
+
+Once activated the minutely probes system runs on every instance of an app.
+This means that if a probe report metrics without some kind of differentiating tag,
+global metrics may be overwritten by instance-level metrics.
+
+To remedy this, we suggest [tagging](/metrics/custom.html#metric-tags) your
+metrics with the hostname or something else unique for each instance.
+For example, the ErlangVM Probe tags metrics with the hostname by default.
+
+Alternatively you can [disable minutely probes](/elixir/configuration/options.html#option-enable_minutely_probes) for all but one instance, on which the minutely probes process is run. We suggest using the [`APPSIGNAL_ENABLE_MINUTELY_PROBES`](/elixir/configuration/options.html#option-enable_minutely_probes) environment variable to only enable it on the instance of your choosing.
+
+## Configuration
+
+The minutely probes are configured using the [`enable_minutely_probes`](/elixir/configuration/options.html#option-enable_minutely_probes) config option. The default value is `true`.
+
+## Creating probes
+
+If you want to track more [custom metrics](/metrics/custom.html) from your app
+than our default proves do, you can add your own prove(s).
+
+An AppSignal minutely probe can be an [Anonymous function](#anonymous-function), or a [Module based function](#module-based-function).
+
+### Anonymous function
+
+The simplest probe type to register. If you have no dependencies for your probe
+this is the preferred method.
+
+```elixir
+Appsignal.Probes.register(:my_probe, fn ->
+  Appsignal.set_gauge("database_size", 10)
+end)
+```
+
+### Module based function
+
+A module based function can be useful if you have a more complex probe, or a
+probe that has dependencies.
+
+```ruby
+# lib/my_app/probes/my_probe.ex
+defmodule MyApp.MyProbe do
+  def call do
+    Appsignal.set_gauge("database_size", 10)
+  end
+end
+```
+
+Now you can register this probe in the start function of your OTP app.
+
+```elixir
+Appsignal.Probes.register(:my_probe, &MyApp.MyProbe.call/0)
+```
+
+## Registering probes
+
+Probes can be registered with the `register` method on the `Appsignal.Probes`
+module.
+This method accepts two arguments.
+
+- `key` - This is the key/name of the probe. This will be used to identify the probe in case an error occurs while executing the probe (which will be logged to the [appsignal.log file](/support/debugging.html#logs)) and to [override an existing probe](#overriding-default-probes).
+- `probe` - This is one of the [supported probe types](#creating-probes) that should be called every minute to collect metrics.
+
+You need to register a probe in your application's `start/2` function, just
+before the supervisor is started.
+
+In a Phoenix app this will look like this:
+
+```elixir
+# lib/my_app/application.ex
+def start(_type, _args) do
+  children = [
+    MyApp.Repo,
+    MyAppWeb.Endpoint,
+  ]
+
+  Appsignal.Probes.register(:my_probe, &MyProbe.call/0)
+
+  opts = [strategy: :one_for_one, name: Weekmenu.Supervisor]
+  Supervisor.start_link(children, opts)
+end
+```
+
+## Overriding default probes
+
+AppSignal ships with a default ErlangVM probe. If for any reason this probe does not function properly or requires some additional configuration for your use case, you can override the default probe by registering a custom probe with the key `:erlang`
+
+Overriding probes will log a debug message in the [appsignal.log file](/support/debugging.html#logs) which can help to detect if a probe is correctly overridden.

--- a/source/elixir/instrumentation/minutely-probes.html.md
+++ b/source/elixir/instrumentation/minutely-probes.html.md
@@ -2,10 +2,7 @@
 title: "Minutely probes"
 ---
 
-Minutely probes are a mechanism to periodically send custom metrics to AppSignal.
-This is a system that is included in the AppSignal Elixir package by default.
-At the start of every minute the minutely probes are triggered one by one to
-collect metrics and then snoozed until the next minute.
+Minutely probes are a mechanism to periodically send [custom metrics](/metrics/custom.html) to AppSignal. This is a system that is included in the AppSignal Elixir package by default. At the start of every minute the minutely probes are triggered to collect metrics and then snoozed until the next minute.
 
 By default the AppSignal Elixir gem enables a probe for the ErlangVM.
 
@@ -24,18 +21,13 @@ By default the AppSignal Elixir gem enables a probe for the ErlangVM.
 
 ## Usage
 
-The minutely probes allow the AppSignal Elixir package to collect [custom metrics](/metrics/custom.html)
-by default for the ErlangVM and app-specific metrics by [creating your own probe](#creating-probes).
+The minutely probes allow the AppSignal Elixir package to collect [custom metrics](/metrics/custom.html) by default for the ErlangVM and app-specific metrics by [creating your own probe](#creating-probes).
 
 ### Multiple instances
 
-Once activated the minutely probes system runs on every instance of an app.
-This means that if a probe report metrics without some kind of differentiating tag,
-global metrics may be overwritten by instance-level metrics.
+Once activated, the minutely probes system runs on every instance of an app. This means that if a probe report metrics without some kind of differentiating tag, global metrics may be overwritten by instance-level metrics.
 
-To remedy this, we suggest [tagging](/metrics/custom.html#metric-tags) your
-metrics with the hostname or something else unique for each instance.
-For example, the ErlangVM Probe tags metrics with the hostname by default.
+To remedy this, we suggest [tagging](/metrics/custom.html#metric-tags) your metrics with the hostname or something else unique for each instance. For example, the ErlangVM Probe tags metrics with the hostname by default.
 
 Alternatively you can [disable minutely probes](/elixir/configuration/options.html#option-enable_minutely_probes) for all but one instance, on which the minutely probes process is run. We suggest using the [`APPSIGNAL_ENABLE_MINUTELY_PROBES`](/elixir/configuration/options.html#option-enable_minutely_probes) environment variable to only enable it on the instance of your choosing.
 
@@ -45,15 +37,13 @@ The minutely probes are configured using the [`enable_minutely_probes`](/elixir/
 
 ## Creating probes
 
-If you want to track more [custom metrics](/metrics/custom.html) from your app
-than our default probes do, you can add your own probe(s).
+If you want to track more [custom metrics](/metrics/custom.html) from your app than our default probes do, you can add your own probe(s).
 
 An AppSignal minutely probe can be an [Anonymous function](#anonymous-function), or a [Module based function](#module-based-function).
 
 ### Anonymous function
 
-The simplest probe type to register. If you have no dependencies for your probe
-this is the preferred method.
+The simplest probe type to register. If you have no dependencies for your probe this is the preferred method.
 
 ```elixir
 Appsignal.Probes.register(:my_probe, fn ->
@@ -63,8 +53,7 @@ end)
 
 ### Module based function
 
-A module based function can be useful if you have a more complex probe, or a
-probe that has dependencies.
+A module based function can be useful if you have a more complex probe, or a probe that has dependencies.
 
 ```ruby
 # lib/my_app/probes/my_probe.ex
@@ -83,15 +72,13 @@ Appsignal.Probes.register(:my_probe, &MyApp.MyProbe.call/0)
 
 ## Registering probes
 
-Probes can be registered with the `register` method on the `Appsignal.Probes`
-module.
+Probes can be registered with the `register` method on the `Appsignal.Probes` module.
 This method accepts two arguments.
 
 - `key` - This is the key/name of the probe. This will be used to identify the probe in case an error occurs while executing the probe (which will be logged to the [appsignal.log file](/support/debugging.html#logs)) and to [override an existing probe](#overriding-default-probes).
 - `probe` - This is one of the [supported probe types](#creating-probes) that should be called every minute to collect metrics.
 
-You need to register a probe in your application's `start/2` function, just
-before the supervisor is started.
+To add a probe, register it in your application's `start/2` function, just before the supervisor is started.
 
 In a Phoenix app this will look like this:
 
@@ -112,6 +99,14 @@ end
 
 ## Overriding default probes
 
-AppSignal ships with a default ErlangVM probe. If for any reason this probe does not function properly or requires some additional configuration for your use case, you can override the default probe by registering a custom probe with the key `:erlang`
+AppSignal ships with default probes for certain [integrations](/ruby/integrations/). If for any reason this probe does not function properly or requires some additional configuration for your use case, you can override the default probe by registering a new probe with the same key.
+
+```elixir
+# lib/my_app/application.ex
+
+Appsignal.Probes.register(:erlang, fn() ->
+  # Do things
+end)
+```
 
 Overriding probes will log a debug message in the [appsignal.log file](/support/debugging.html#logs) which can help to detect if a probe is correctly overridden.

--- a/source/elixir/instrumentation/minutely-probes.html.md
+++ b/source/elixir/instrumentation/minutely-probes.html.md
@@ -9,8 +9,6 @@ collect metrics and then snoozed until the next minute.
 
 By default the AppSignal Elixir gem enables a probe for the ErlangVM.
 
--> **Note**: This feature is turned on by default in AppSignal Elixir package `1.10.1` and up.
-
 -> **Note**: We recommend using AppSignal Elixir package `1.10.1` and up when using this feature.
 
 ## Table of Contents

--- a/source/ruby/instrumentation/minutely-probes.html.md
+++ b/source/ruby/instrumentation/minutely-probes.html.md
@@ -2,7 +2,7 @@
 title: "Minutely probes"
 ---
 
-Minutely probes are a mechanism to periodically send custom metrics to AppSignal. This is a system that is included in the AppSignal Ruby gem by default. At the start of every minute the minutely probes are triggered one by one to collect metrics and then snoozed until the next minute.
+Minutely probes are a mechanism to periodically send [custom metrics](/metrics/custom.html) to AppSignal. This is a system that is included in the AppSignal Ruby gem by default. At the start of every minute the minutely probes are triggered one by one to collect metrics and then snoozed until the next minute.
 
 By default the AppSignal Ruby gem enables probes for [libraries](/ruby/integrations) that are detected for your app.
 
@@ -29,7 +29,7 @@ The minutely probes allow the AppSignal Ruby gem to collect [custom metrics](/me
 
 ### Multiple instances
 
-Once activated the minutely probes system runs on every instance of an app. This means that if a probe report metrics without some kind of differentiating tag, global metrics may be overwritten by instance-level metrics. For example, there's a probe that tracks how large the local background job queue is for an app. The queue database runs locally on the instance and queue sizes may vary wildly. Each instance of an app reports different metric values for the same metric and tags, overwriting the metric value every minute with those of the last reporting instance.
+Once activated, the minutely probes system runs on every instance of an app. This means that if a probe report metrics without some kind of differentiating tag, global metrics may be overwritten by instance-level metrics. For example, there's a probe that tracks how large the local background job queue is for an app. The queue database runs locally on the instance and queue sizes may vary wildly. Each instance of an app reports different metric values for the same metric and tags, overwriting the metric value every minute with those of the last reporting instance.
 
 To remedy this, we suggest [tagging](/metrics/custom.html#metric-tags) your metrics with the hostname or something else unique for each instance. For example, the [Sidekiq probe](/ruby/integrations/sidekiq.html#minutely-probe) tags metrics with the Redis hostname by default.
 


### PR DESCRIPTION
This adds the docs for the Elixir Minutely Probe. It is mostly based on the Ruby version.