### PR TITLE
Add Elixir 1.9 release binary instructions to diagnose page

### DIFF
--- a/source/support/debugging.html.md
+++ b/source/support/debugging.html.md
@@ -40,7 +40,11 @@ appsignal diagnose
 
 # Elixir
 mix appsignal.diagnose
-# Or with the release binary
+
+# With an Elixir release (`mix release`) binary:
+bin/your_app eval ":appsignal_tasks.diagnose()"
+
+# With a Distillery release binary:
 bin/your_app command appsignal_tasks diagnose
 ```
 


### PR DESCRIPTION
Elixir 1.9's release binaries have a different way to run internal commands, so the `appsignal_tasks` solution we've been using for Distillery won't work.