### PR TITLE
Mention the Phoenix integration dependency on the Absinthe page

### DIFF
--- a/source/elixir/integrations/absinthe.html.md
+++ b/source/elixir/integrations/absinthe.html.md
@@ -16,6 +16,8 @@ Absinthe apps in Phoenix do lack a controller and action name registered in the 
 
 ## Absinthe Plug
 
+-> **Note:** The Absinthe support relies on AppSignal's Phoenix integration. Follow the [Phoenix integration guide](https://docs.appsignal.com/elixir/integrations/phoenix.html) before adding the Absinthe Plug.
+
 A small fix is required for Absinthe Phoenix apps to set the action name manually for the Absinthe requests. The following plug can be used to set the action name for Absinthe requests. Make sure to specify the correct `request_path` in the `call/2` function.
 
 You'll also be able to configure the action name for these requests yourself by changing the value given to `Appsignal.Transaction.set_action/1`.

--- a/source/elixir/integrations/absinthe.html.md
+++ b/source/elixir/integrations/absinthe.html.md
@@ -16,7 +16,7 @@ Absinthe apps in Phoenix do lack a controller and action name registered in the 
 
 ## Absinthe Plug
 
--> **Note:** The Absinthe support relies on AppSignal's Phoenix integration. Follow the [Phoenix integration guide](https://docs.appsignal.com/elixir/integrations/phoenix.html) before adding the Absinthe Plug.
+-> **Note:** The Absinthe support relies on AppSignal's Phoenix integration. Follow the [Phoenix integration guide](/elixir/integrations/phoenix.html) before adding the Absinthe Plug.
 
 A small fix is required for Absinthe Phoenix apps to set the action name manually for the Absinthe requests. The following plug can be used to set the action name for Absinthe requests. Make sure to specify the correct `request_path` in the `call/2` function.
 


### PR DESCRIPTION
Add another note to explain using the Absinthe Plug still requires using the Phoenix integration. 