### PR TITLE
Add separate Slack integration page

### DIFF
--- a/source/_side_nav.html.haml
+++ b/source/_side_nav.html.haml
@@ -37,6 +37,7 @@
             %li= link_with_active "Intercom", "/application/integrations/intercom.html"
             %li= link_with_active "Jira", "/application/integrations/jira.html"
             %li= link_with_active "PagerDuty", "/application/integrations/pagerduty.html"
+            %li= link_with_active "Slack", "/application/integrations/slack.html"
             %li= link_with_active "Webhooks", "/application/integrations/webhooks.html"
 
     %li.section

--- a/source/application/integrations/index.html.md
+++ b/source/application/integrations/index.html.md
@@ -23,7 +23,7 @@ To enable notifications and issue tracker integration for external services, go 
 - [PagerDuty](/application/integrations/pagerduty.html)
 - [Phabricator](#phabricator)
 - [Pivotal Tracker](#pivotal-tracker)
-- [Slack](#slack)
+- [Slack](/application/integrations/slack.html)
 - [Trello](#trello)
 - [Webhook](/application/integrations/webhooks.html)
 
@@ -107,12 +107,6 @@ Website: [https://phacility.com/phabricator/](https://phacility.com/phabricator/
 Simple, collaborative project management from the experts in agile software development.
 
 Website: [http://www.pivotaltracker.com/](http://www.pivotaltracker.com/)
-
-## Slack
-
-Slack brings all your communication together in one place. It's real-time messaging, archiving and search for modern teams.
-
-Website: [https://www.slack.com](https://www.slack.com)
 
 ## Trello
 

--- a/source/application/integrations/slack.html.md
+++ b/source/application/integrations/slack.html.md
@@ -1,0 +1,21 @@
+---
+title: Slack
+description: "Learn more about how to set up the AppSignal Slack app for your Slack team."
+---
+
+Slack brings all your communication together in one place. It's real-time messaging, archiving and search for modern teams.
+
+Website: [Slack.com](https://www.slack.com)
+
+## Installation
+
+- To install the AppSignal Slack app, click the install button below to start the installation process.
+- You will be shown a page with a drop-down from which you can select the app on AppSignal.com to install the app on.
+- From there you will be redirected to the notifier install page for the Slack app.
+- Click the install button here too.
+- You will now be redirected to the Slack App Directory to install the AppSignal Slack app for the team of your choosing.
+- Finally, select a channel to which AppSignal should post notifications about errors, performance measurements and other Anomaly detection alerts you have set up.
+
+<a href="https://appsignal.com/redirect-to/app?to=notifiers/new/slack" class="button small">Install the AppSignal Slack app</a>
+
+_Alternatively, open the app you want to have Slack notifications for on [AppSignal.com](https://appsignal.com), in the app navigation open "Notifications", choose "Slack" from the "Add integration" drop-down. Then on the Slack notifier page you can start the install process._


### PR DESCRIPTION
Create a page with separate more detailed installation instructions for
the Slack integration.

Part of https://github.com/appsignal/appsignal-server/issues/3071