### PR TITLE
Fix import statements in front-end plugin docs

### DIFF
--- a/source/front-end/plugins/plugin-path-decorator.html.md
+++ b/source/front-end/plugins/plugin-path-decorator.html.md
@@ -5,7 +5,7 @@ title: "plugin-path-decorator"
 The `plugin-path-decorator` is a plugin that decorates all outgoing `Span`s with the current path. This is computed by reading from `window.location.pathname`.
 
 ```javascript
-import { plugin } from `appsignal/plugin-window-events`
+import { plugin } from `@appsignal/plugin-path-decorator`
 appsignal.use(plugin(options))
 ```
 

--- a/source/front-end/plugins/plugin-window-events.html.md
+++ b/source/front-end/plugins/plugin-window-events.html.md
@@ -5,7 +5,7 @@ title: "plugin-window-events"
 The `plugin-window-events` plugin binds to the `window.onerror` and `window.onunhandledrejection` event handlers to catch any errors that are otherwise not caught elsewhere in your code.
 
 ```javascript
-import { plugin } from `appsignal/plugin-window-events`
+import { plugin } from `@appsignal/plugin-window-events`
 appsignal.use(plugin(options))
 ```
 


### PR DESCRIPTION
Fixes some incorrect import statements in the front-end documentation, as reported on Slack.