### PR TITLE
Add page about Ecto/Telemetry configuration

### DIFF
--- a/source/_side_nav.html.haml
+++ b/source/_side_nav.html.haml
@@ -142,6 +142,7 @@
           %ul
             %li= link_with_active "Phoenix", "/elixir/integrations/phoenix.html"
             %li= link_with_active "Plug", "/elixir/integrations/plug.html"
+            %li= link_with_active "Ecto", "/elixir/integrations/ecto.html"
             %li= link_with_active "Erlang", "/elixir/integrations/erlang.html"
         %li
           = link_with_active "Custom instrumentation", "/elixir/instrumentation/"

--- a/source/elixir/integrations/ecto.html.md
+++ b/source/elixir/integrations/ecto.html.md
@@ -1,0 +1,31 @@
+# Instrumenting Ecto queries
+
+AppSignal uses Ecto’s Telemetry instrumentation to gain information about queries ran in your app by attaching a handler that gets called whenever a query is executed.
+
+To get this to work, you attach the handler manually when starting your app’s supervisor. In most applications, this is done in your application’s `start/2` function.
+
+``` elixir
+def start(_type, _args) do
+  children = [
+    AppsignalPhoenixExample.Repo,
+    AppsignalPhoenixExampleWeb.Endpoint
+  ]
+
+  :telemetry.attach(
+    "appsignal-ecto",
+    [:appsignal_phoenix_example, :repo, :query],
+    &Appsignal.Ecto.handle_event/4,
+    nil
+  )
+  
+  opts = [strategy: :one_for_one, name: AppsignalPhoenixExample.Supervisor]
+  Supervisor.start_link(children, opts)
+end
+```
+
+In this example, we’ve attached the Telemetry handler to our Phoenix application by calling `:telemetry.attach/4` with the following arguments:
+
+1. `"appsignal-ecto"` is the name of the handler. This should be unique. If you have multiple repos you’d like to have instrumentation for, give each a unique name (like `"appsignal-ecto-1"` and `"appsignal-ecto-2"`).
+2. `[:appsignal_phoenix_example, :repo, :query]` is the name of the event to watch. It’s made up of the repo module’s name (`AppsignalPhoenixExample.Repo`), and the event name (`:query`).
+3. `&Appsignal.Ecto.handle_event/4` is the function the event will be sent to in the AppSignal integration.
+4. We’ll omit the handler configuration by passing `nil` as the fourth argument. 

--- a/source/elixir/integrations/ecto.html.md
+++ b/source/elixir/integrations/ecto.html.md
@@ -29,3 +29,26 @@ In this example, we’ve attached the Telemetry handler to our Phoenix applicati
 2. `[:appsignal_phoenix_example, :repo, :query]` is the name of the event to watch. It’s made up of the repo module’s name (`AppsignalPhoenixExample.Repo`), and the event name (`:query`).
 3. `&Appsignal.Ecto.handle_event/4` is the function the event will be sent to in the AppSignal integration.
 4. We’ll omit the handler configuration by passing `nil` as the fourth argument. 
+
+## Telemetry < 0.3
+
+For versions of Telemetry &lt; 0.3.0, you'll need to call it slightly differently:
+
+```elixir
+Telemetry.attach(
+  "appsignal-ecto",
+  [:appsignal_phoenix_example, :repo, :query],
+  Appsignal.Ecto,
+  :handle_event,
+  nil
+)
+```
+
+## Ecto < 3.0
+
+On Ecto 2, add the `Appsignal.Ecto` module to your Repo's logger configuration instead. The `Ecto.LogEntry` logger is the default logger for Ecto and needs to be set as well to keep the original Ecto logger behavior intact.
+
+```elixir
+config :my_app, MyApp.Repo,
+  loggers: [Appsignal.Ecto, Ecto.LogEntry]
+```

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -95,33 +95,7 @@ If you're using Ecto 3, attach `Appsignal.Ecto` to Telemetry query events in you
 )
 ```
 
-For versions of Telemetry &lt; 0.3.0, you'll need to call it slightly differently:
-
-```elixir
-Telemetry.attach(
-  "appsignal-ecto",
-  [:my_app, :repo, :query],
-  Appsignal.Ecto,
-  :handle_event,
-  nil
-)
-```
-
--> **Note**: Telemetry's handler ID (the first argument to the `:telemetry.attach/4` function) needs to be unique across your application. Make sure to use unique IDs when attaching the Ecto integration to multiple Repos.
-
-On Ecto 2, add the `Appsignal.Ecto` module to your Repo's logger configuration instead. The `Ecto.LogEntry` logger is the default logger for Ecto and needs to be set as well to keep the original Ecto logger behavior intact.
-
-```elixir
-config :my_app, MyApp.Repo,
-  loggers: [Appsignal.Ecto, Ecto.LogEntry]
-```
-
--> **Note**: Telemetry support was added in version 1.8.2 of the AppSignal for
-Elixir integration.
-
-Note that this is not Phoenix-specific but works for all Ecto queries. The
-process that performs the query however, must be associated with an
-`Appsignal.Transaction`, otherwise no event will be logged.
+For more information on query instrumentation and installation instructions for Telemetry < 0.3.0 and Ecto < 3.0, check out the [AppSignal Ecto documentation](/elixir/integration/ecto.html).
 
 ## Channels
 


### PR DESCRIPTION
Although still a bit of a stub, this page explains how the Ecto/Telemetry configuration works, and how each of the parameters passed to it work.