### PR TITLE
Add front-end documentation for handling CORS errors:

### DIFF
--- a/source/_side_nav.html.haml
+++ b/source/_side_nav.html.haml
@@ -191,6 +191,7 @@
             %li= link_with_active "plugin-breadcrumbs-network", "/front-end/plugins/plugin-breadcrumbs-network.html"
             %li= link_with_active "plugin-window-events", "/front-end/plugins/plugin-window-events.html"
             %li= link_with_active "plugin-path-decorator", "/front-end/plugins/plugin-path-decorator.html"
+        %li= link_with_active "Troubleshooting", "/front-end/troubleshooting.html"
 
   %ul
     %li.section

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -17,7 +17,7 @@ You can then import and use the package in your bundle:
 import Appsignal from "@appsignal/javascript" // For ES Module
 const Appsignal = require("@appsignal/javascript").default // For CommonJS module
 
-const appsignal = new Appsignal({ 
+const appsignal = new Appsignal({
   key: "YOUR FRONTEND API KEY"
 })
 ```
@@ -33,6 +33,28 @@ export default new Appsignal({
 ```
 
 Currently, we have no plans to supply a CDN-hosted version of this library.
+
+!> **NOTE:** If you are running a CDN in front of your assets, you'll need to make two changes for error reporting to be able to send errors to our API endpoint. These changes are described below.
+
+### Front-end monitoring and CDN's
+
+First, on your CDN add a cross-origin(CORS) header:
+
+```
+Access-Control-Allow-Origin: *
+```
+
+And in your app make sure the `crossorigin` attribute is present in all your JavaScript tags.
+
+```html
+<script type="text/javascript" src="//cdn.example.com/bundle.js" crossorigin>
+```
+
+Or if you are using a Rails helper:
+
+```ruby
+  <%= javascript_include_tag "application", :crossorigin => :anonymous %>
+```
 
 ### Supported browsers
 

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -34,7 +34,7 @@ export default new Appsignal({
 
 Currently, we have no plans to supply a CDN-hosted version of this library.
 
-!> **NOTE:** If you are running a CDN in front of your assets, you'll need to make two changes for error reporting to be able to send errors to our API endpoint. These changes are described [here](/front-end/troubleshooting.html).
+!> **NOTE:** If you are running a CDN in front of your assets, you'll need to make [two changes](/front-end/troubleshooting.html) for error reporting to be able to send errors to our API endpoint. Read more about the [required changes](/front-end/troubleshooting.html).
 
 ### Supported browsers
 

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -34,27 +34,7 @@ export default new Appsignal({
 
 Currently, we have no plans to supply a CDN-hosted version of this library.
 
-!> **NOTE:** If you are running a CDN in front of your assets, you'll need to make two changes for error reporting to be able to send errors to our API endpoint. These changes are described below.
-
-### Front-end monitoring and CDN's
-
-First, on your CDN add a cross-origin(CORS) header:
-
-```
-Access-Control-Allow-Origin: *
-```
-
-And in your app make sure the `crossorigin` attribute is present in all your JavaScript tags.
-
-```html
-<script type="text/javascript" src="//cdn.example.com/bundle.js" crossorigin>
-```
-
-Or if you are using a Rails helper:
-
-```ruby
-  <%= javascript_include_tag "application", :crossorigin => :anonymous %>
-```
+!> **NOTE:** If you are running a CDN in front of your assets, you'll need to make two changes for error reporting to be able to send errors to our API endpoint. These changes are described [here](/front-end/troubleshooting.html).
 
 ### Supported browsers
 

--- a/source/front-end/troubleshooting.html.md
+++ b/source/front-end/troubleshooting.html.md
@@ -2,7 +2,13 @@
 title: "Troubleshooting"
 ---
 
-### My assets are hosted on a CDN and I see the following log message in the console: "Cross-domain or eval script error detected, error ignored"
+## CDN hosted assets
+
+Your app's assets are hosted on a CDN and you see the following warning message in the browser's web console:
+
+```
+Cross-domain or eval script error detected, error ignored
+```
 
 This is normal browser behaviour and is a consequence of the [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy), a security measure designed to protect your users from [Cross-Site Request Forgery](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)) (CSRF) attacks. Luckily, this is a fairly easy problem to remedy.
 

--- a/source/front-end/troubleshooting.html.md
+++ b/source/front-end/troubleshooting.html.md
@@ -1,0 +1,25 @@
+---
+title: "Troubleshooting"
+---
+
+### My assets are hosted on a CDN and I see the following log message in the console: "Cross-domain or eval script error detected, error ignored"
+
+This is normal browser behaviour and is a consequence of the [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy), a security measure designed to protect your users from [Cross-Site Request Forgery](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)) (CSRF) attacks. Luckily, this is a fairly easy problem to remedy.
+
+First, on your CDN, add a cross-origin (CORS) header:
+
+```
+Access-Control-Allow-Origin: *
+```
+
+In your app, make sure the `crossorigin` attribute is present in all your JavaScript tags.
+
+```html
+<script type="text/javascript" src="//cdn.example.com/bundle.js" crossorigin="anonymous">
+```
+
+Or if you are using a Rails helper:
+
+```ruby
+<%= javascript_include_tag "application", :crossorigin => :anonymous %>
+```


### PR DESCRIPTION
Closes https://github.com/appsignal/appsignal-docs/issues/253.

```
Cross-domain or eval script error detected, error ignored
```