### PR TITLE
Split the uninstall guide per language

### DIFF
--- a/source/application/index.html.md
+++ b/source/application/index.html.md
@@ -53,22 +53,22 @@ Read more about the AppSignal [working directory](/appsignal/how-appsignal-opera
 
 ## Removing an application
 
-An application (app) in AppSignal is the combination of the application name and environment, e.g. "My app - production". You can only delete one environment at a time through the UI.
+An application (app) in AppSignal is defined as the combination of the application name and environment, e.g. "My app - production". You can only delete one environment at a time through the UI.
 
-To remove an app from AppSignal a couple things need to be done to make sure it's removed completely and won't continue to send data to AppSignal's servers.
+Apps are automatically recreated when our servers receive data from your app. To remove an app, first make sure AppSignal is completely uninstalled from your applications before removing it on AppSignal.com
 
-- First remove the AppSignal integration (Ruby gem, Elixir package and JavaScript packages) from your app and deploy your app.
-- Remove any AppSignal configuration files and system environment variables.
-- Redeploy your application. This will make sure the AppSignal servers won't continue to receive data from your app.
-  - Make sure all your webservers are restarted.
-  - Make sure no `appsignal-agent` processes are running in the background.
-- Then, on [AppSignal.com](https://appsignal.com/accounts), open the app you want to delete.
-  - Click on "App settings" to open the settings page.
-  - Scroll down to the bottom of the page.
-  - In the "Delete &lt;app name&gt;" section, click on the "delete &lt;app name&gt;" button and confirm the confirmation prompt.
+Please follow the uninstall guide for the programming language of your application(s) listed below:
+
+- [Ruby gem uninstall guide](/ruby/installation.html#uninstall)
+- [Elixir package uninstall guide](/elixir/installation.html#uninstall)
+- [JavaScript for Front-end package uninstall guide](/front-end/installation.html#uninstall)
+
+When your app is no longer pushing data to the AppSignal servers, delete your app on the [App Settings page](https://appsignal.com/redirect-to/app?to=edit) for your app on AppSignal.com.
+
+- Visit the [App Settings](https://appsignal.com/redirect-to/app?to=edit) page.
+- Scroll down to the bottom of the page.
+- In the "Delete &lt;app name&gt;" section, click on the "delete &lt;app name&gt;" button and confirm the confirmation prompt.
 
 Your app is now scheduled for deletion. It and all its data will be removed from your organization and our servers. This may take a few minutes, after which it will disappear from your apps list.
-
-**Note**: If your app keeps pushing data, because one or more servers are still pushing app data or host metrics for this app, we will create a new app with the same name and environment. Make sure your servers have restarted and the `appsignal-agent` process is no longer running on any of the hosts.
 
 [Application index]: https://appsignal.com/accounts

--- a/source/elixir/installation.html.md
+++ b/source/elixir/installation.html.md
@@ -4,16 +4,22 @@ title: "Installing AppSignal for Elixir"
 
 Please follow the [installation guide](/application/new-application.html) when adding a new application to AppSignal.
 
-Installing the AppSignal package in your Elixir application requires a couple
-manual steps. Currently pure Elixir applications and the Phoenix framework are
-supported. Both use-cases are described in this guide.
+## Table of Contents
 
-If AppSignal does not support your use-case or if you find a problem with the
-documentation, don't hesitate to [contact us][support]. You can also create a
-pull-request on our public [Elixir repository][elixir-repo] or [documentation
-repository][docs-repo].
+- [Installation](#installation)
+  - [Requirements](#requirements)
+  - [Configuration](#configuration)
+      - [Manual configuration](#manual-configuration)
+  - [Run your application!](#run-your-application)
+  - [Optional: Add Phoenix instrumentation](#optional-add-phoenix-instrumentation)
+  - [Optional: Add custom instrumentation](#optional-add-custom-instrumentation)
+- [Uninstall](#uninstall)
 
 ## Installation
+
+Installing the AppSignal package in your Elixir application requires a couple manual steps. Currently pure Elixir applications and the Phoenix framework are supported. Both use-cases are described in this guide.
+
+If AppSignal does not support your use-case or if you find a problem with the documentation, don't hesitate to [contact us][support]. You can also create a pull-request on our public [Elixir repository][elixir-repo] or [documentation repository][docs-repo].
 
 ### Requirements
 
@@ -49,7 +55,7 @@ If it can't find a valid configuration, a warning will be logged. See
 the [Configuration](#configuration) section on how to fully configure the
 AppSignal agent.
 
-## Configuration
+### Configuration
 
 Before the AppSignal package works you need to configure it. To be able to send
 data to AppSignal you first need to [create an account on
@@ -64,7 +70,7 @@ or manually configure AppSignal using the guide below.
 For more information about configuring the AppSignal package for Elixir, please
 read our [configuration documentation](/elixir/configuration/index.html).
 
-### Manual configuration
+#### Manual configuration
 
 If you want to manually configure AppSignal you will need to place the
 AppSignal Push API key you receive in the installation process in your
@@ -93,7 +99,7 @@ export APPSIGNAL_APP_ENV="prod"
 For more information about configuring the AppSignal package for Elixir, please
 read our [configuration options page](/elixir/configuration/index.html).
 
-## Run your application!
+### Run your application!
 
 Once you've completed this guide your application is ready to be monitored by
 AppSignal!
@@ -104,17 +110,35 @@ error or two you'll also test the error reporting.
 [Contact us][support] if you have questions regarding installation or
 encountered any problems during the installation.
 
-## Optional: Add Phoenix instrumentation
+### Optional: Add Phoenix instrumentation
 
 Read more about how you can integrate more instrumentation in your Phoenix
 application in our [integrating Phoenix
 guide](/elixir/integrations/phoenix.html).
 
-## Optional: Add custom instrumentation
+### Optional: Add custom instrumentation
 
 Add custom instrumentation to your application to get a more in-depth view of
 what's happening in your application. Read more about custom instrumentation in
 our [instrumentation documentation](/elixir/instrumentation/index.html).
+
+## Uninstall
+
+Uninstall AppSignal from your app by following the steps below. When these steps are completed your app will no longer send data to the AppSignal servers.
+
+1. In the `mix.exs` of your app, delete the `{:appsignal, "~> 1.0"}` line.
+1. Run `mix deps.get` to update your `mix.lock` with the removed packages state.
+1. Remove any AppSignal [configuration files](/elixir/configuration/) from your app.
+  - Configuration file location: `config/appsignal.exs`
+  - And its references in any other files in `config/*.exs`
+1. Remove any system environment variables from your development, staging, production, etc. hosts.
+  - Environment variables prefixed with `APPSIGNAL_`
+  - Environment variable [`APP_REVISION`](/elixir/configuration/options.html#option-revision)
+1. Commit, deploy and restart your app.
+  - This will make sure the AppSignal servers won't continue to receive data from your app.
+1. Optional: Make sure no `appsignal-agent` processes are running in the background.
+  - Check the output of `ps aux | grep appsigal-agent` and kill the processes still running.
+1. Finally, [remove the app](/application/#removing-an-application) on AppSignal.com
 
 [support]: mailto:support@appsignal.com
 [elixir-repo]: https://github.com/appsignal/appsignal-elixir

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -2,6 +2,19 @@
 title: "Installing AppSignal for JavaScript"
 ---
 
+## Table of Contents
+
+- [Installation](#installation)
+  - [Requirements](#requirements)
+  - [Configuration](#configuration)
+      - [Manual configuration](#manual-configuration)
+  - [Run your application!](#run-your-application)
+  - [Optional: Add Phoenix instrumentation](#optional-add-phoenix-instrumentation)
+  - [Optional: Add custom instrumentation](#optional-add-custom-instrumentation)
+- [Uninstall](#uninstall)
+
+## Installation
+
 First, add the `@appsignal/javascript` package to your `package.json`. Then, run `yarn install`/`npm install`. You'll also need a Push API key from the ["Push and deploy" section](https://appsignal.com/redirect-to/app?to=info) of your App settings page.
 
 You can also add these packages to your `package.json` on the command line:
@@ -41,3 +54,14 @@ Currently, we have no plans to supply a CDN-hosted version of this library.
 This package can be used in any ECMAScript 5 compatible browser. We aim for compatibility down to Internet Explorer 9 [(roughly 0.22% of all browsers used today)](https://www.w3counter.com/globalstats.php). All browsers older than this can only supported on a “best effort” basis, and full functionality cannot be guaranteed.
 
 When developing, don’t forget to check browser support on [Can I Use?](https://caniuse.com/) and the [ES6 Compatibility Table](https://kangax.github.io/compat-table/es6/), and provide the appropriate polyfills or fallbacks. **In a small percentage of browsers, a `Promise` polyfill may be required to use this library.**
+
+## Uninstall
+
+Uninstall AppSignal from your app by following the steps below. When these steps are completed your app will no longer send data to the AppSignal servers.
+
+1. In the `package.json` of your app, delete all lines referencing an `appsignal` package: `"*appsignal/*": "*"`.
+1. Run `npm install` or `yarn install` to update your `package.lock`/`yarn.lock` with the removed packages state.
+1. Remove any AppSignal [configuration](/front-end/configuration/) from your app.
+1. Commit, deploy and restart your app.
+  - This will make sure the AppSignal servers won't continue to receive data from your app.
+1. Finally, [remove the app](/application/#removing-an-application) on AppSignal.com

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -61,6 +61,7 @@ Uninstall AppSignal from your app by following the steps below. When these steps
 
 1. In the `package.json` of your app, delete all lines referencing an `appsignal` package: `"*appsignal/*": "*"`.
 1. Run `npm install` or `yarn install` to update your `package.lock`/`yarn.lock` with the removed packages state.
+   - Alternatively, run `npm uninstall @appsignal/<package name>` or `yarn remove @appsignal/<package name>` to uninstall an AppSignal package.
 1. Remove any AppSignal [configuration](/front-end/configuration/) from your app.
 1. Commit, deploy and restart your app.
   - This will make sure the AppSignal servers won't continue to receive data from your app.

--- a/source/ruby/installation.html.md
+++ b/source/ruby/installation.html.md
@@ -2,6 +2,15 @@
 title: "Installing AppSignal for Ruby"
 ---
 
+Please follow the [installation guide](/application/new-application.html) when adding a new application to AppSignal.
+
+## Table of Contents
+
+- [Installation](#installation)
+  - [Requirements](#requirements)
+  - [Installing the gem](#installing-the-gem)
+- [Uninstall](#uninstall)
+
 ## Installation
 
 Please follow the [installation guide](/application/new-application.html) when adding a new application to AppSignal.
@@ -35,3 +44,20 @@ bundle exec appsignal install YOUR_PUSH_API_KEY
 This will present you with an installation script that can integrate automatically in some frameworks and gems and will allow you to configure AppSignal.
 
 For more information on how to integrate AppSignal into your application see the [integrations documentation](/ruby/integrations/index.html) to see what steps are necessary.
+
+## Uninstall
+
+Uninstall AppSignal from your app by following the steps below. When these steps are completed your app will no longer send data to the AppSignal servers.
+
+1. In the `Gemfile` of your app, delete the `gem "appsignal"` line.
+1. Run `bundle install` to update your `Gemfile.lock` with the removed gem state.
+1. Remove any AppSignal [configuration files](/ruby/configuration/) from your app.
+  - Configuration file location: `config/appsignal.yml`
+1. Remove any system environment variables from your development, staging, production, etc. hosts.
+  - Environment variables prefixed with `APPSIGNAL_`
+  - Environment variable [`APP_REVISION`](/ruby/configuration/options.html#option-revision)
+1. Commit, deploy and restart your app.
+  - This will make sure the AppSignal servers won't continue to receive data from your app.
+1. Optional: Make sure no `appsignal-agent` processes are running in the background.
+  - Check the output of `ps aux | grep appsigal-agent` and kill the processes still running.
+1. Finally, [remove the app](/application/#removing-an-application) on AppSignal.com


### PR DESCRIPTION
Split the uninstall guide for every language we support so the
installation instructions are specific to the language and we don't
confuse people with mentions of other tools.

Add it the bottom of the installation page so it's easier to find,
grouped with the guide to install it.

Related to https://github.com/appsignal/appsignal-ruby/issues/574