### PR TITLE
Beter namespace filter explanation/example.

### DIFF
--- a/source/ruby/instrumentation/namespaces.html.md
+++ b/source/ruby/instrumentation/namespaces.html.md
@@ -66,8 +66,10 @@ For more information about this config option, see the [`ignore_namespaces` conf
 ```yaml
 default: &defaults
   ignore_namespaces:
-    - "admin"
-    - "private"
+    - "http_request" # "web" namespace on AppSignal
+    - "background_job" # "background" namespace on AppSignal
+    - "action_cable"
+    - "frontend"
 ```
 
 You can also configure ignore namespaces using an environment variable.


### PR DESCRIPTION
In the docs we talk about ignoring namespaces, but the namespaces in
our Ruby implementation and the web application are named differently.

This commit changes the example to show the values used in the Ruby
implementation, as the filtering happens there.