### PR TITLE
Use AppSignal.Plug.set_action/2

### DIFF
--- a/source/elixir/integrations/plug.html.md
+++ b/source/elixir/integrations/plug.html.md
@@ -30,8 +30,12 @@ use the `Appsignal.Plug` module.
 
 The Plug integration [doesn’t automatically extract the request’s action
 name](https://docs.appsignal.com/support/known-issues/plug-actions-registered-as-unknown.html).
-Call `Appsignal.Transaction.set_action/1` in your action to set the action name
+Call `Appsignal.Plug.set_action/2` in your action to set the action name
 for your requests to prevent your requests to be categorised as “unknown”.
+
+-> **Note**: `Appsignal.Plug.set_action/2` was added in version 1.12.0 of the
+AppSignal for Elixir package. Use `Appsignal.Transaction.set_action/1` on
+earlier versions.
 
 ``` elixir
 defmodule AppsignalPlugExample do

--- a/source/support/known-issues/plug-actions-registered-as-unknown.html.md
+++ b/source/support/known-issues/plug-actions-registered-as-unknown.html.md
@@ -14,11 +14,16 @@ In versions before version 1.5.0-beta.1, `Appsignal.Plug` used the request metho
 
 ## Workaround
 
-To override the "unknown" action name, use `Appsignal.Transaction.set_action/1` from anywhere within the action.
+To override the "unknown" action name, use `Appsignal.Plug.set_action/2` from anywhere within the action.
 
 ```elixir
 get "/users/:id" do
-  Appsignal.Transaction.set_action("GET /users/:id")
-  send_resp(conn, 200, "Welcome")
+  conn
+  |> Appsignal.Plug.set_action("GET /users/:id")
+  |> send_resp(200, "Welcome")
 end
 ```
+
+-> **Note**: `Appsignal.Plug.set_action/2` was added in version 1.12.0 of the
+AppSignal for Elixir package. Use `Appsignal.Transaction.set_action/1` on
+earlier versions.


### PR DESCRIPTION
As added in https://github.com/appsignal/appsignal-elixir/pull/538 and
as part of our Phoenix 1.5 support, we now require users to use
AppSignal.Plug.set_action/2 to overwrite action names in Plug and
Phoenix apps from version 1.12.0 onward.

Let's hold off on merging this until 1.12.0 is released.