### PR TITLE
Update Design System to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "webpack-cli": "^3.3.9"
   },
   "dependencies": {
-    "@appsignal/design-system": "appsignal/design-system#master"
+    "@appsignal/design-system": "0.0.1-alpha.4"
   },
   "scripts": {
     "build": "webpack --bail",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,10 @@
 # yarn lockfile v1
 
 
-"@appsignal/design-system@appsignal/design-system#master":
-  version "0.0.0"
-  resolved "https://codeload.github.com/appsignal/design-system/tar.gz/66bc7b14e533df5bcd17d924b3abc3de2361563d"
+"@appsignal/design-system@0.0.1-alpha.4":
+  version "0.0.1-alpha.4"
+  resolved "https://registry.yarnpkg.com/@appsignal/design-system/-/design-system-0.0.1-alpha.4.tgz#6e34a2dda9108fc9390b2e8f97502baf408f9572"
+  integrity sha512-pex+VWnwLOA9+V/jwsECSvs3EUohPHNOCQEjJHVwRh3jDo+z1ezrI0n4pb9N+I37ACGMfLD+x2cUw5vD1rfZKA==
   dependencies:
     tailwindcss "^1.1.3"
     tailwindcss-grid "^1.2.1"


### PR DESCRIPTION
We still ran the docs on the branched version pre-mono-repo era. This updates it to use the NPM package instead of building from GitHub directly.