### PR TITLE
Add note explaining instrumenters are no longer needed

### DIFF
--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -45,7 +45,7 @@ endpoint.
 
 ## Phoenix instrumentation hooks
 
--> **Note**: From AppSignal for Elixir package version `1.12.0` onward, manually configuring Phoenix instrumentation hooks is no longer needed and this step can be skipped.
+-> **Note**: From AppSignal for Elixir package version `1.12.0` onward, manually configuring Phoenix instrumentation hooks is no longer needed and this step can be skipped for apps running Phoenix 1.4.7 and up.
 
 Phoenix comes with instrumentation hooks built-in. To send Phoenix'
 default instrumentation events to AppSignal, add the following to your

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -45,6 +45,8 @@ endpoint.
 
 ## Phoenix instrumentation hooks
 
+-> **Note**: From AppSignal for Elixir package version `1.12.0` onward, manually configuring Phoenix instrumentation hooks is no longer needed.
+
 Phoenix comes with instrumentation hooks built-in. To send Phoenix'
 default instrumentation events to AppSignal, add the following to your
 `config.exs` (adjusting for your app's name!).

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -45,7 +45,7 @@ endpoint.
 
 ## Phoenix instrumentation hooks
 
--> **Note**: From AppSignal for Elixir package version `1.12.0` onward, manually configuring Phoenix instrumentation hooks is no longer needed.
+-> **Note**: From AppSignal for Elixir package version `1.12.0` onward, manually configuring Phoenix instrumentation hooks is no longer needed and this step can be skipped.
 
 Phoenix comes with instrumentation hooks built-in. To send Phoenix'
 default instrumentation events to AppSignal, add the following to your


### PR DESCRIPTION
From 1.12 onward, the instrumenter doesn't need to be configured anymore ([as explained in the release blogpost](https://github.com/appsignal/appsignal-blog/pull/478/files)). Thus, the step could be removed completely.

However, I'm hesitant to remove this altogether, as we use this document to check users with existing setups. Instead, I'd like to propose adding a note here and removing the whole section once this version has been out for a while.