### PR TITLE
Minor docs tweaks for features added in 1.1.1

### DIFF
--- a/source/front-end/configuration/index.html.md
+++ b/source/front-end/configuration/index.html.md
@@ -12,3 +12,4 @@ The `Appsignal` object can be initialized with the following options:
 |  uri  |  string  |  (optional) The full URI of an AppSignal Push API endpoint. This setting will not have to be changed. |
 |  namespace  |  string  |   (optional) A namespace for errors.  |
 |  revision  |  string  |   (optional) A Git SHA of the current revision. |
+|  ignoreErrors  |  RegExp[]  |   (optional) An array of `RegExp`s to check against the `message` property of a given `Error`. If it matches, the error is ignored. |

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -50,6 +50,8 @@ This package can be used in any ECMAScript 5 compatible browser. We aim for comp
 
 When developing, don’t forget to check browser support on [Can I Use?](https://caniuse.com/) and the [ES6 Compatibility Table](https://kangax.github.io/compat-table/es6/), and provide the appropriate polyfills or fallbacks. **In a small percentage of browsers, a `Promise` polyfill may be required to use this library.**
 
+`@appsignal/javascript` also works in React Native/Expo apps!
+
 ## Uninstall
 
 Uninstall AppSignal from your app by following the steps below. When these steps are completed your app will no longer send data to the AppSignal servers.


### PR DESCRIPTION
Adds documentation for the `ignoreErrors` config option, as well as a short sentence on React Native support.