### PR TITLE
Update documentation for AppSignal for Elixir 2.0

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -114,6 +114,15 @@ options:
         Read from environment variable `NODE_ENV`, defaults to "development".
       description: |
         The environment of the app to be reported to AppSignal.
+  - config_key: otp_app
+    env_key: APPSIGNAL_OTP_APP
+    required: true
+    elixir:
+      since: 2.0.0
+      type: string
+      default_value: null
+      description: |
+        The OTP app name of your application, to be used for automatic configuration of instrumentation for libraries like Ecto.
   - config_key: name
     env_key: APPSIGNAL_APP_NAME
     required: true

--- a/source/elixir/configuration/index.html.md
+++ b/source/elixir/configuration/index.html.md
@@ -15,6 +15,7 @@ following items. If they are not present, AppSignal will not send any data to
 AppSignal.com.
 
 - A valid [Push API Key](/appsignal/terminology.html#push-api-key)
+- The application's OTP app name
 - An application name
 - An application environment (`dev` / `prod` / `test`)
 - The application environment to be set to `active: true`
@@ -23,10 +24,11 @@ AppSignal.com.
 # Example minimal config file
 # config/config.exs
 config :appsignal, :config,
-  active: true,
-  name: "My awesome app",
+  otp_app: :appsignal_phoenix_example,
+  name: "AppsignalPhoenixExample",
   push_api_key: "your-push-api-key",
-  env: Mix.env
+  env: Mix.env,
+  active: true
 ```
 
 Alternatively, you can configure the agent using system environment variables.
@@ -34,8 +36,9 @@ AppSignal will automatically become active if the `APPSIGNAL_PUSH_API_KEY`
 environment variable is set.
 
 ```elixir
+export APPSIGNAL_OTP_APP="appsignal_phoenix_example"
 export APPSIGNAL_PUSH_API_KEY="your-push-api-key"
-export APPSIGNAL_APP_NAME="My awesome app"
+export APPSIGNAL_APP_NAME="AppsignalPhoenixExample"
 export APPSIGNAL_APP_ENV="prod"
 ```
 
@@ -87,10 +90,10 @@ config :appsignal, :config,
 ```elixir
 # config/config.exs
 config :appsignal, :config,
-  active: true,
-  name: "My awesome app",
+  otp_app: :appsignal_phoenix_example,
+  name: "AppsignalPhoenixExample",
   push_api_key: "your-push-api-key",
-  env: Mix.env
+  env: Mix.env,
 ```
 
 ```elixir

--- a/source/elixir/configuration/load-order.html.md
+++ b/source/elixir/configuration/load-order.html.md
@@ -48,8 +48,11 @@ configuration file.
 # config/config.exs
 # or config/prod.exs
 config :appsignal, :config,
-  name: :my_app,
-  push_api_key: "your-push-api-key"
+  otp_app: :appsignal_phoenix_example,
+  name: "AppsignalPhoenixExample",
+  push_api_key: "your-push-api-key",
+  env: Mix.env,
+  active: true
 ```
 
 This step will override all given options from the defaults or system
@@ -64,7 +67,7 @@ When found these will override all given configuration options from
 previous steps.
 
 ```bash
-export APPSIGNAL_APP_NAME="my custom app name"
+export APPSIGNAL_APP_NAME="AppsignalPhoenixExample"
 # start your app here
 ```
 

--- a/source/elixir/installation/index.html.md
+++ b/source/elixir/installation/index.html.md
@@ -6,13 +6,13 @@ Please follow the [installation guide](/guides/new-application.html) first, when
 
 ## Installation
 
-Installing the AppSignal package in your Elixir application requires a couple manual steps. Currently pure Elixir applications and the Phoenix framework are supported. Both use-cases are described in this guide.
+Installing the AppSignal package in your Elixir application requires a couple of manual steps. Currently, AppSignal support Phoenix, Plug and pure Elixir apps.
 
 If AppSignal does not support your use-case or if you find a problem with the documentation, don't hesitate to [contact us][support]. You can also create a pull-request on our public [Elixir repository][elixir-repo] or [documentation repository][docs-repo].
 
 ### Requirements
 
-Before you can compile the AppSignal package make sure the build/compilation tools are installed for your system. Please check the [Supported Operating Systems](/support/operating-systems.html) page for any system dependencies that may be required.
+Before you can compile the AppSignal package, make sure the build/compilation tools are installed for your system. Please check the [Supported Operating Systems](/support/operating-systems.html) page for any system dependencies that may be required.
 
 ### Installing the package
 
@@ -26,7 +26,7 @@ Before you can compile the AppSignal package make sure the build/compilation too
     # mix.exs
     def deps do
       [
-        {:appsignal, "~> 1.0"},
+        {:appsignal, "~> 2.0"},
         {:jason, "~> 1.1"}
       ]
     end
@@ -36,7 +36,7 @@ Before you can compile the AppSignal package make sure the build/compilation too
 3. Then run `mix appsignal.install YOUR_PUSH_API_KEY` or follow the [manual configuration guide](#configuration).
 4. If you use the [Phoenix framework][phoenix], continue with the [integrating AppSignal into Phoenix](/elixir/integrations/phoenix.html) guide.
 
-After the installation is complete start your application. When the AppSignal
+After the installation is complete, start your application. When the AppSignal
 OTP application starts, it looks for a valid configuration (e.g. an AppSignal
 Push API key), and start the AppSignal agent.
 
@@ -71,17 +71,19 @@ name and environment and more.
 ```elixir
 # config/config.exs
 config :appsignal, :config,
-  active: true,
-  name: "My awesome app",
+  otp_app: :appsignal_phoenix_example,
+  name: "AppsignalPhoenixExample",
   push_api_key: "your-push-api-key",
-  env: Mix.env
+  env: Mix.env,
+  active: true
 ```
 
 Alternatively, you can configure AppSignal using OS environment variables.
 
 ```sh
+export APPSIGNAL_OTP_APP="appsignal_phoenix_example"
 export APPSIGNAL_PUSH_API_KEY="your-push-api-key"
-export APPSIGNAL_APP_NAME="My awesome app"
+export APPSIGNAL_APP_NAME="AppsignalPhoenixExample"
 export APPSIGNAL_APP_ENV="prod"
 ```
 
@@ -119,7 +121,7 @@ our [instrumentation documentation](/elixir/instrumentation/index.html).
 
 Uninstall AppSignal from your app by following the steps below. When these steps are completed your app will no longer send data to the AppSignal servers.
 
-1. In the `mix.exs` of your app, delete the `{:appsignal, "~> 1.0"}` line.
+1. In the `mix.exs` of your app, delete the `{:appsignal, "~> 2.0"}` line.
 1. Run `mix deps.get` to update your `mix.lock` with the removed packages state.
 1. Remove any AppSignal [configuration files](/elixir/configuration/) from your app.
   - Configuration file location: `config/appsignal.exs`

--- a/source/elixir/installation/umbrella.html.md
+++ b/source/elixir/installation/umbrella.html.md
@@ -12,7 +12,7 @@ Add the AppSignal dependency to each application that will use it. This includes
 
 ```elixir
 defp deps do
-  {:appsignal, "~> 1.0"}
+  {:appsignal, "~> 2.0"}
 end
 ```
 
@@ -24,58 +24,17 @@ By default, each nested application in an umbrella uses the main umbrella config
 
 ## Phoenix
 
-The installation for Phoenix in an umbrella application are mostly the same as [setting up AppSignal “regular” Phoenix application](/elixir/integrations/phoenix.html), but there are a few things to keep in mind.
+The installation for Phoenix in an umbrella application are mostly the same as
+[setting up AppSignal “regular” Phoenix
+application](/elixir/integrations/phoenix.html). One thing to keep in mind is
+to `use Appsignal.Phoenix` in your application’s endpoint file. If you have
+multiple nested Phoenix applications, use the module in each.
 
-1. `use Appsignal.Phoenix` in your application’s endpoint file. If you have multiple nested Phoenix applications, use the module in each.
+```elixir
+defmodule AppsignalPhoenixExampleWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :appsignal_phoenix_example
+  use Appsignal.Phoenix
 
-    ```elixir
-    defmodule AppsignalPhoenixExampleWeb.Endpoint do
-      use Phoenix.Endpoint, otp_app: :appsignal_phoenix_example
-      use Appsignal.Phoenix
-
-      # ...
-    end
-    ```
-
-2. Add the instrumentation hooks to the endpoint configuration in your umbrella app’s `config/config.exs` file:
-
-    ```elixir
-    config :appsignal_phoenix_example_web, AppsignalExampleWeb.Endpoint,
-      instrumenters: [Appsignal.Phoenix.Instrumenter]
-    ```
-
-3. Add the template engines to the Phoenix configuration by adding this configuration block to your umbrella app’s `config/config.exs` file:
-
-    ```elixir
-    config :phoenix, :template_engines,
-      eex: Appsignal.Phoenix.Template.EExEngine,
-      exs: Appsignal.Phoenix.Template.ExsEngine
-    ```
-
-4. Add the Ecto instrumentation hooks to each application that use Ecto, in the applications' `start/2` functions:
-
-    ```elixir
-    defmodule AppsignalExample.Application do
-
-      # ...
-
-      def start(_type, _args) do
-        children = [
-          AppsignalExample.Repo
-        ]
-
-        :telemetry.attach(
-          "appsignal-ecto",
-          [:appsignal_example, :repo, :query],
-          &Appsignal.Ecto.handle_event/4,
-          nil
-        )
-
-        Supervisor.start_link(children, strategy: :one_for_one, name: AppsignalExample.Supervisor)
-      end
-    end
-    ```
-
-Don’t forget to change `:appsignal_example` to your OTP application name, and make sure it matches your repo’s module name. If your repo module is called `AppsignalExample.Repo`, attach to `[:appsignal_example, :repo, :query]`.
-
-If you have multiple repo modules in your application, make sure to use a unique name for each attachment. Instead of using “appsignal-ecto” for both, use “appsignal-ecto-2” for the second, for example.
+  # ...
+end
+```

--- a/source/elixir/instrumentation/exception-handling.html.md
+++ b/source/elixir/instrumentation/exception-handling.html.md
@@ -18,20 +18,21 @@ The AppSignal configuration makes it possible to [ignore
 errors](/elixir/configuration/ignore-errors.html). By providing a list of
 specific errors AppSignal will not send alerts when these errors are raised.
 
-## Appsignal.Transaction.set_error/3
+## Appsignal.set_error/3
 
 If you want to rescue exceptions in your application to prevent crashes, but
 still want to track the occurrence you can use
-[`Appsignal.Transaction.set_error/3`][hexdocs-set_error] to add the exception
-to the current AppSignal transaction.
+[`Appsignal.set_error/3`][hexdocs-set_error] to add the exception to the
+current AppSignal transaction.
 
 ```elixir
 try do
-  raise("Oh no!")
-rescue
-  e ->
-    stack = System.stacktrace
-    Appsignal.Transaction.set_error("ExceptionName", "error message", stack)
+  raise "Exception!"
+catch
+  kind, reason ->
+    stack = __STACKTRACE__
+
+    Appsignal.set_error(kind, reason, stack)
 end
 ```
 
@@ -42,29 +43,30 @@ you to provide custom error handling and fallbacks.
 Otherwise the error will be ignored.
 
 Please see
-[`Appsignal.send_error/6`](#appsignal-send_error-6) for sending errors
+[`Appsignal.send_error/3`](#appsignal-send_error-3) for sending errors
 without an AppSignal transaction.
 
-## Appsignal.send_error/6
+## Appsignal.send_error/3
 
 AppSignal provides a mechanism to track errors that occur in code that's not in
 a web or background job context, such as Mix tasks. This is useful for
 instrumentation that doesn't automatically create AppSignal transactions to
 profile.
 
-You can use the [`Appsignal.send_error/6`][hexdocs-send_error] function to
+You can use the [`Appsignal.send_error/3`][hexdocs-send_error] function to
 directly send an exception to AppSignal from any place in your code without
 starting an AppSignal transaction first.
 
 ```elixir
 try do
-  raise "Oops!"
-rescue
-  e ->
-    stack = System.stacktrace
-    Appsignal.send_error(e, "error message", stack)
+  raise "Exception!"
+catch
+  kind, reason ->
+    stack = __STACKTRACE__
+
+    Appsignal.send_error(kind, reason, stack)
 end
 ```
 
-[hexdocs-set_error]: https://hexdocs.pm/appsignal/Appsignal.Transaction.html#set_error/3
-[hexdocs-send_error]: https://hexdocs.pm/appsignal/Appsignal.html#send_error/6
+[hexdocs-set_error]: https://hexdocs.pm/appsignal/Appsignal.Instrumentation.html#set_error/3
+[hexdocs-send_error]: https://hexdocs.pm/appsignal/Appsignal.Instrumentation.html#send_error/3

--- a/source/elixir/instrumentation/instrumentation.html.md
+++ b/source/elixir/instrumentation/instrumentation.html.md
@@ -25,11 +25,99 @@ package](https://hexdocs.pm/appsignal/).
    your code. To track errors please read our
    [exception handling](/elixir/instrumentation/exception-handling.html) guide.
 
+## `Appsignal.instrument/2-3`
+
+The `instrument/2` function is used to add instrumentation by wrapping a piece
+of code in a span. A span eventually becomes a sample, or an event in another
+span's sample in AppSignal.
+
+### Add spans to traces
+
+In the following example we have a Phoenix controller with an `index/2`
+function which calls a slow function. The `slow` function is instrumented using
+the `Appsignal.instrument/2` function which records it as a separate event in
+this Phoenix request. It will show up on AppSignal.com in the event timeline of
+this sample to provide more insight in where the most time was spent during the
+request.
+
+```elixir
+defmodule AppsignalPhoenixExampleWeb.PageController do
+  use AppsignalPhoenixExampleWeb, :controller
+
+  def index(conn, _params) do
+    slow()
+    render(conn, "index.html")
+  end
+
+  defp slow do
+    Appsignal.instrument("slow", fn ->
+      :timer.sleep(1000)
+    end)
+  end
+end
+```
+
+Here, we wrap our function's contents with a call to `Appsignal.instrument3`,
+and we pass `"slow"` as the name for the event.
+
+### Starting new traces
+
+In the Phoenix example an AppSignal trace has already been started, thanks to
+the first-party support for Phoenix in the AppSignal package. Not all
+frameworks and packages are currently supported directly and automatically
+start traces. The same is true for your own pure Elixir applications.
+
+Like when adding spans to already-instrumented traces, a new root span is
+created using the `Appsignal.instrument/2` function:
+
+```elixir
+defmodule AppsignalElixirExample do
+  def instrument do
+    Appsignal.instrument("instrument", fn ->
+      :timer.sleep(500)
+    end)
+  end
+end
+```
+
+This example creates a sample named "instrument" in the "background" namespace
+in AppSignal. The name will also be used as the category name for the main
+span. To use a different category name, use `instrument/3` instead:
+
+```elixir
+defmodule AppsignalElixirExample do
+  def instrument do
+    Appsignal.instrument("instrument", "call.instrument", fn ->
+      :timer.sleep(500)
+    end)
+  end
+end
+```
+
+When passing a function that takes an argument, the `instrument/2-3` function
+calls it with the opened span to allow further customization:
+
+```elixir
+defmodule AppsignalElixirExample do
+  def instrument do
+    Appsignal.instrument("instrument", "call.instrument", fn span ->
+      Appsignal.Span.set_namespace(span, "custom_namespace")
+      :timer.sleep(500)
+    end)
+  end
+end
+```
+
+###^helper Exception handling
+
+To report errors using custom instrumentation please read more in our
+[exception handling guide](/elixir/instrumentation/exception-handling.html).
+
 ## Function decorators
 
 Using the `Appsignal.Instrumentation.Decorators` decorator module, it's
-possible quickly add custom instrumentation to your Elixir applications without
-a lot of code.
+possible add custom instrumentation to your Elixir applications without
+changing the functions' contents.
 
 ###^decorator Transaction events
 
@@ -59,9 +147,6 @@ defmodule PhoenixExample.PageController do
   end
 end
 ```
-
-By default the instrumented functions have no parent group. They are grouped
-under the "other" group. A group all unknown event groups are grouped under.
 
 If you want to group certain events together under the same event group (other
 group are `phoenix_controller`, `phoenix_render`, `ecto`, etc.) you can also
@@ -185,288 +270,4 @@ end
 Channel events will be displayed under the "background" namespace, showing the
 channel module and the action argument that it's used on.
 
-## Instrumentation helper functions
 
-Using the instrumentation helpers it's possible to add custom instrumentation
-while retaining a lot of control over what is instrumented.
-
-See also the [appsignal package on hexdocs](https://hexdocs.pm/appsignal) for
-code documentation.
-
-###^helper Instrument helper
-
-In the following example we have a Phoenix controller with an `index/2`
-function which performs a couple of complex operations. We will add an
-instrumentation function to instrument this complex code. The data collected
-during the execution of this code will show up on AppSignal.com in the event
-timeline of this transaction sample. It will help provide more insight in where
-the most time was spent during the request.
-
-For more information on what event names to use in the `instrument/3` and `instrument/4` functions, please read our [event naming guidelines](/api/event-names.html).
-
-```elixir
-# Phoenix controller example
-defmodule PhoenixExample.PostController do
-  use PhoenixExample.Web, :controller
-  # Include this
-  import Appsignal.Instrumentation.Helpers, only: [instrument: 3]
-
-  def index(conn, _params) do
-    # Instrument a block of code
-    instrument("query.posts", "Fetching all posts", fn() ->
-      # Database queries
-
-      # Instrument a nested block of code
-      data = instrument("request.s3", "Fetching related post data", fn() ->
-        # Third-party API request
-      end)
-
-      instrument("linking.posts", "Linking post data together", fn() ->
-        # Linking database data and S3 data
-        # Enum.each(data, fn(x) -> "link post to third-party data" end)
-      end)
-
-      # etc
-    end)
-
-    render conn, "index.html"
-  end
-end
-```
-
-**Note**: On Elixir integration versions before 1.1.1, you'll need to pass the
-current transaction to `instrument/4`.
-
-```elixir
-# Phoenix controller example
-defmodule PhoenixExample.PostController do
-  use PhoenixExample.Web, :controller
-  # Include instrument/4 instead of instrument/3
-  import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
-
-  def index(conn, _params) do
-   # Get the current transaction
-   transaction = Appsignal.TransactionRegistry.lookup(self())
-
-    # Pass the transaction as the first argument to instrument/4
-    instrument(transaction, "query.posts", "Fetching all posts", fn() ->
-      # etc
-    end)
-
-    render conn, "index.html"
-  end
-end
-```
-
-#### Adding asynchronous events to a transaction
-
-To add asynchronous events to a transaction in another process there are a couple things to keep in mind. These events can not exceed the runtime of the parent transaction. If they finish after a transaction is completed the events will be registered incompletely, as they don't have a end-time. They will also appear to miss some metadata such as an event name, title and body.
-
-A process spawned by a Phoenix controller can't run longer than it takes for the request to complete. If so, a new transaction should be started within that new process instead. For more information on how to start and complete transactions, see our [transactions section](#helper-transactions). These transactions cannot be linked together at this time. To wait for an asynchronous process before completing the transaction you can use something like [`Task.await/2`](https://hexdocs.pm/elixir/Task.html#await/2), see the example below.
-
-To add events to another process' transaction you can pass along the `PID` of a process to the `instrument/4` function. If a transaction exists for that process, the event will be registered on that transaction, otherwise it's ignored.
-
-Make sure to wait for the process in which another event is tracked before completing the transaction.
-
-```elixir
-# Phoenix controller example
-defmodule PhoenixExample.PostController do
-  use PhoenixExample.Web, :controller
-  # Include instrument/4 instead of instrument/3
-  import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
-
-  def index(conn, _params) do
-    parent = self()
-    task = Task.async(fn ->
-      instrument(parent, "foo.bar", "TEST", fn() ->
-        :timer.sleep(1000)
-      end)
-    end)
-
-    # Do other things while the task is running
-
-    # And wait for the task
-    Task.await(task)
-
-    # Then return the request
-    text conn, "Done!"
-  end
-end
-```
-
-###^helper Transactions
-
-In the Phoenix example an AppSignal transaction has already been started,
-thanks to the first-party support for Phoenix in the AppSignal package. Not all
-frameworks and packages are currently supported directly and automatically
-start transactions. The same is true for your own pure Elixir applications.
-
-In order to track the instrumentation functions we will need to start an
-AppSignal transaction beforehand. We can start a transaction with
-`Appsignal.Transaction.start/2`. Once a transaction is started we can add
-transaction events that are recorded by
-`Appsignal.Instrumentation.Helpers.instrument/4`.
-
-```elixir
-# Pure Elixir example
-defmodule InstrumentationHelpersExample do
-  # Include this
-  import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
-
-  def call do
-    # Start an AppSignal transaction
-    transaction = Appsignal.Transaction.start(
-      Appsignal.Transaction.generate_id,
-      :http_request
-    )
-    # Set the action name
-    |> Appsignal.Transaction.set_action("InstrumentationExample/instrumented_function")
-
-    instrument(transaction, "query.posts", "Fetching all posts", fn() ->
-      # Database queries
-    end)
-
-    # Finish and close the transaction
-    Appsignal.Transaction.finish(transaction)
-    Appsignal.Transaction.complete(transaction)
-  end
-end
-```
-
-**Note**: When using pure Elixir applications, make sure that the AppSignal
-application is started before you start a transaction. For more information,
-see how to
-[integrate AppSignal](/elixir/instrumentation/integrating-appsignal.html).
-
-###^helper Transaction metadata
-
-Now we have recorded a simple transaction, but the transaction sample itself
-might not provide enough context to where the issue occurred or in what
-scenario. To provide more context to the sample we can add more metadata to a
-transaction.
-
-```elixir
-transaction = Appsignal.Transaction.start(
-  Appsignal.Transaction.generate_id,
-  :http_request
-)
-# Set the action name of the module/controller and function which is instrumented
-|> Appsignal.Transaction.set_action("InstrumentationExample#instrumented_function")
-# Add extra data to the transaction. See also our Tagging guide.
-|> Appsignal.Transaction.set_sample_data(
-  "environment", %{request_path: "/hello", method: "GET"}
-)
-```
-
-There are also helpers available for when the transaction is not available.
-When these are used AppSignal will add the metadata to the currently active
-transaction if any.
-
-```elixir
-Appsignal.Transaction.set_action("InstrumentationExample/instrumented_function")
-
-# And
-Appsignal.Transaction.set_sample_data(
-  "environment", %{request_path: "/hello", method: "GET"}
-)
-```
-
-###^helper Namespaces
-
-In order to differentiate between HTTP requests and background jobs we can pass
-a namespace to the transaction once we start it.
-
-The following two namespaces are official namespaces supported by AppSignal.
-
-- `http_request` - the default - is called the "web" namespace
-- `background_job` - creates the "background" namespace
-
-```elixir
-Appsignal.Transaction.start(
-  Appsignal.Transaction.generate_id,
-  :background_job
-)
-```
-
-For more information about what namespaces are, please see our
-[namespaces](/application/namespaces.html) documentation.
-
-###^helper Custom namespaces
-
-You can also create your own namespaces to track transactions in a separate
-part of your application such as an administration panel. This will group all
-the transactions with this namespace in a separate section on AppSignal.com so
-that slow admin controllers don't interfere with the averages of your
-application's speed.
-
-```elixir
-Appsignal.Transaction.start(
-  Appsignal.Transaction.generate_id,
-  :admin
-)
-```
-
-###^helper Exception handling
-
-To report errors using custom instrumentation please read more in our
-[exception handling guide](/elixir/instrumentation/exception-handling.html).
-
-###^helper Example
-
-This example is set up as procedural as possible so any setup doesn't distract
-from the order in which to execute things. You may want to wrap certain parts
-in separate functions to make it more reusable.
-
-```elixir
-defmodule InstrumentationExample do
-  # Include this
-  import Appsignal.Instrumentation.Helpers, only: [instrument: 4]
-
-  def instrumented_function do
-    # Start an AppSignal transaction
-    transaction = Appsignal.Transaction.start(
-      Appsignal.Transaction.generate_id,
-      :http_request
-    )
-    # Set the action name of the module/controller and function which is instrumented
-    |> Appsignal.Transaction.set_action("InstrumentationExample/instrumented_function")
-    # Add extra data to the transaction. See also our Tagging guide.
-    |> Appsignal.Transaction.set_sample_data(
-      "environment", %{request_path: "/hello", method: "GET"}
-    )
-
-    try do
-      # Instrument specific blocks of code
-      instrument(transaction, "complex.function", "Rendering something slow", fn() ->
-        :timer.sleep(100)
-
-        # Nest instrumentation
-        instrument(transaction, "request.third_party_api", "Slow API call", fn() ->
-          :timer.sleep(300)
-        end)
-
-        instrument(transaction, "query.custom_database", "Slow query", fn() ->
-          :timer.sleep(5000)
-        end)
-
-        # Raise an error, not required of course.
-        raise("Exception!")
-      end)
-    rescue
-      e ->
-        # Report an error in this transaction.
-        # It will then be reported as an error instead of a performance issue.
-        Appsignal.Transaction.set_error(
-          transaction,
-          "SomeError",
-          "So what went wrong was that I raised an exception earlier..",
-          System.stacktrace
-        )
-    end
-
-    # Finish and close the transaction
-    Appsignal.Transaction.finish(transaction)
-    Appsignal.Transaction.complete(transaction)
-  end
-end
-```

--- a/source/elixir/instrumentation/integrating-appsignal.html.md
+++ b/source/elixir/instrumentation/integrating-appsignal.html.md
@@ -39,7 +39,7 @@ of your application.
   defp deps do
     [
       # ...
-      {:appsignal, "~> 1.0"}
+      {:appsignal, "~> 2.0"}
     ]
   end
 

--- a/source/elixir/instrumentation/tagging.html.md
+++ b/source/elixir/instrumentation/tagging.html.md
@@ -2,12 +2,12 @@
 title: "Tagging and Sample Data"
 ---
 
-Use the [`Appsignal.Transaction.set_sample_data`](https://hexdocs.pm/appsignal/Appsignal.Transaction.html#set_sample_data/2) function to supply extra context on errors and
+Use the [`Appsignal.Span.set_sample_data`](https://hexdocs.pm/appsignal/Appsignal.Span.html#set_sample_data/2) function to supply extra context on errors and
 performance issues. This can help to add information that is not already part of
 the request, session or environment parameters.
 
 ```elixir
-Appsignal.Transaction.set_sample_data("tags", %{locale: "en"})
+Appsignal.Span.set_sample_data("tags", %{locale: "en"})
 ```
 
 !> **Warning**: Do not use tagging to send personal data such as names or email
@@ -29,9 +29,9 @@ Tags that do not meet these limitations are dropped without warning.
 `set_sample_data` can be called multiple times, but only the last value will be retained:
 
 ```elixir
-Appsignal.Transaction.set_sample_data("tags", %{locale: "en"})
-Appsignal.Transaction.set_sample_data("tags", %{user: "bob"})
-Appsignal.Transaction.set_sample_data("tags", %{locale: "de"})
+Appsignal.Span.set_sample_data("tags", %{locale: "en"})
+Appsignal.Span.set_sample_data("tags", %{user: "bob"})
+Appsignal.Span.set_sample_data("tags", %{locale: "de"})
 ```
 will result in the following data:
 
@@ -57,7 +57,7 @@ Besides tags you can add more metadata to a transaction (or override default met
 Filled with session/cookie data by default, but can be overridden with the following call:
 
 ```
-Appsignal.Transaction.set_sample_data("session_data", %{_csrf_token: "Z11CWRVG+I2egpmiZzuIx/qbFb/60FZssui5eGA8a3g="})
+Appsignal.Span.set_sample_data("session_data", %{_csrf_token: "Z11CWRVG+I2egpmiZzuIx/qbFb/60FZssui5eGA8a3g="})
 ```
 
 This key accepts nested objects that will be rendered as JSON on a Incident Sample page for both Exception and Performance samples.
@@ -70,7 +70,7 @@ This key accepts nested objects that will be rendered as JSON on a Incident Samp
 Filled with framework (such as Phoenix) parameters by default, but can be overridden or filled with the following call:
 
 ```
-Appsignal.Transaction.set_sample_data("params", %{action: "show", controller: "homepage"})
+Appsignal.Span.set_sample_data("params", %{action: "show", controller: "homepage"})
 ```
 
 This key accepts nested objects and will show up as follows on a Incident Sample page for both Exception and Performance samples, formatted as JSON.
@@ -83,7 +83,7 @@ This key accepts nested objects and will show up as follows on a Incident Sample
 Environment variables from a request/background job, filled by the Phoenix integration, but can be filled/overriden with the following call:
 
 ```
-Appsignal.Transaction.set_sample_data("environment", %{CONTENT_LENGTH: "0"})
+Appsignal.Span.set_sample_data("environment", %{CONTENT_LENGTH: "0"})
 ```
 
 This call only accepts a one-level key/value object, nested values will be ignored.
@@ -97,7 +97,7 @@ This will result the following block on a Incident Sample page for both Exceptio
 Custom data is not set by default, but can be used to add additional debugging data to solve a performance issue or exception.
 
 ```
-Appsignal.Transaction.set_sample_data("custom_data", %{foo: "bar"})
+Appsignal.Span.set_sample_data("custom_data", %{foo: "bar"})
 ```
 This key accepts nested objects and will result in the following block on a Incident Sample page for both Exception and Performance samples formatted as JSON.
 

--- a/source/elixir/integrations/ecto.html.md
+++ b/source/elixir/integrations/ecto.html.md
@@ -2,7 +2,28 @@
 
 AppSignal uses Ecto’s Telemetry instrumentation to gain information about queries ran in your app by attaching a handler that gets called whenever a query is executed.
 
-To get this to work, you attach the handler manually when starting your app’s supervisor. In most applications, this is done in your application’s `start/2` function.
+## Automatic instrumentation
+
+The Ecto instrumentation automatically hooks into your Ecto repos if you've set your `:otp_app` configuration to match your app's OTP app name. The new installer wil automatically set that option, but you'll need to add it to your appsignal.exs  config file manually when upgrading:
+
+``` elixir
+config :appsignal, :config,
+  otp_app: :appsignal_phoenix_example, <--
+  name: "appsignal_phoenix_example",
+  push_api_key: "your-api-key",
+  env: Mix.env
+```
+
+The integration thens use your app's configuration to find out which repos are configured, as your app will have a configuration line like this in config/config.exs :
+
+``` elixir
+config :appsignal_phoenix_example,
+  ecto_repos: [AppsignalPhoenixExample.Repo]
+```
+
+## Manual handler attachment
+
+For repos that aren't listed in the `:ecto_repos` configuration, you can attach a handler manually when starting your app’s supervisor. In most applications, this is done in your application’s `start/2` function.
 
 ``` elixir
 def start(_type, _args) do
@@ -54,13 +75,4 @@ Telemetry.attach(
   :handle_event,
   nil
 )
-```
-
-## Ecto < 3.0
-
-On Ecto 2, add the `Appsignal.Ecto` module to your Repo's logger configuration instead. The `Ecto.LogEntry` logger is the default logger for Ecto and needs to be set as well to keep the original Ecto logger behavior intact.
-
-```elixir
-config :my_app, MyApp.Repo,
-  loggers: [Appsignal.Ecto, Ecto.LogEntry]
 ```

--- a/source/elixir/integrations/index.html.md
+++ b/source/elixir/integrations/index.html.md
@@ -8,3 +8,5 @@ guide](/elixir/instrumentation/integrating-appsignal.html).
 
 * [Phoenix](phoenix.html)
 * [Plug](plug.html)
+* [Ecto](ecto.html)
+* [Erlang](erlang.html)

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -13,6 +13,29 @@ instrumentation](/elixir/instrumentation/index.html) documentation.
 More information can be found in the [AppSignal Hex package
 documentation][hex-appsignal].
 
+## Getting started
+
+Since version 2.0, the Phoenix integration is moved to a separate library named
+`:appsignal_phoenix`, which depends on the main `:appsignal` library. To use
+AppSignal in a Phoenix app, add `:appsignal_phoenix` to your dependencies. You
+can then remove the `:appsignal` dependency.
+
+``` elixir
+defmodule AppsignalPhoenixExample.MixProject do
+  # ...
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.5.3"},
+      # ...
+      {:appsignal_phoenix, "~> 2.0.0"}
+    ]
+  end
+
+  # ...
+end
+```
+
 ## Incoming HTTP requests
 
 To start logging HTTP requests in your Phoenix app, make sure you use the

--- a/source/elixir/integrations/plug.html.md
+++ b/source/elixir/integrations/plug.html.md
@@ -22,11 +22,6 @@ We'll start out with a small Plug app that accepts `GET` requests to `/` and
 returns a welcome message. To start logging HTTP requests in this app, we'll
 use the `Appsignal.Plug` module.
 
-The Plug integration [doesn’t automatically extract the request’s action
-name](https://docs.appsignal.com/support/known-issues/plug-actions-registered-as-unknown.html).
-Call `Appsignal.Transaction.set_action/1` in your action to set the action name
-for your requests to prevent your requests to be categorised as “unknown”.
-
 ``` elixir
 defmodule AppsignalPlugExample do
   use Plug.Router
@@ -36,8 +31,6 @@ defmodule AppsignalPlugExample do
   plug :dispatch
 
   get "/" do
-    Appsignal.Transaction.set_action("GET /") # <- Set the action name
-
     send_resp(conn, 200, "Welcome")
   end
 end
@@ -54,17 +47,11 @@ instrumentation.
 
 This example app looks like the one we used before, but it has a slow function
 (aptly named `slow/0`) we'd like to add instrumentation for. To do that, we need
-to
-
-1. `use Appsignal.Instrumentation.Decorators` to allow us to use AppSignal's
-   instrumentation decorators
-2. Decorate the function we want to instrument with the `transaction_event/0`
-   decorator
+to use the `Appsignal.instrument/2-3` helper in our called function:
 
 ``` elixir
 defmodule AppsignalPlugExample do
   use Plug.Router
-  use Appsignal.Instrumentation.Decorators # <-- 1
 
   plug :match
   plug :dispatch
@@ -74,9 +61,10 @@ defmodule AppsignalPlugExample do
     send_resp(conn, 200, "Welcome")
   end
 
-  @decorate transaction_event() # <-- 2
   defp slow do
-    :timer.sleep(1000)
+    Appsignal.Instrument("slow", fn ->
+      :timer.sleep(1000)
+    end)
   end
 
   use Appsignal.Plug
@@ -95,56 +83,20 @@ helpers or decorators.
 
 ### Plug instrumentation with decorators
 
-To add instrumentation to Plugs, use the `Appsignal.Instrumentation.Decorators`
-module, and decorate your Plug's `call/2` function using the
-`transaction_event/0-1` function.
+To add instrumentation to Plugs, use the `Appsignal.instrument/2` function:
 
 ``` elixir
 defmodule SlowPlugWithDecorators do
   import Plug.Conn
-  # use Appsignal's decorators
-  use Appsignal.Instrumentation.Decorators
-
-  def init(opts), do: opts
-
-  # Decorate the call/2 function to add custom instrumentation
-  @decorate transaction_event()
-  def call(conn, _) do
-    :timer.sleep(1000)
-    conn
-  end
-end
-```
-
-See the
-[`transaction_event`](https://docs.appsignal.com/elixir/instrumentation/instrumentation.html#decorator-transaction-events)
-documentation for more information.
-
-### Plug instrumentation without decorators
-
-Instead of using the decorators, you can use the `instrument/3` method to
-decorate a block of code directly.
-
-``` elixir
-defmodule SlowPlugWithInstrumentationHelpers do
-  import Plug.Conn
-  # Import the instrument-function
-  import Appsignal.Instrumentation.Helpers, only: [instrument: 3]
 
   def init(opts), do: opts
 
   def call(conn, _) do
-    # Wrap the contents of the call/2 function in an instrumentation block
-    instrument("timer.sleep", "Sleeping", fn() ->
+    Appsignal.instrument("SlowPlugWithDecorators", fn ->
       :timer.sleep(1000)
       conn
     end)
   end
 end
 ```
-
-See the [instrumentation
-helpers](https://docs.appsignal.com/elixir/instrumentation/instrumentation.html#instrumentation-helper-functions)
-documentation for more information.
-
 [hex-appsignal]: https://hexdocs.pm/appsignal/

--- a/source/guides/namespaces.html.md
+++ b/source/guides/namespaces.html.md
@@ -94,7 +94,7 @@ defmodule AppsignalPhoenixExampleWeb.AdminController do
   defp set_appsignal_namespace(conn, _params) do
     # Configures all actions in this controller to report
     # in the "admin" namespace
-    Appsignal.Transaction.set_namespace(:admin)
+    Appsignal.Span.set_namespace(Appsignal.Tracer.current_span(), "admin")
     conn
   end
 
@@ -108,7 +108,7 @@ In a background job call the `Appsignal.Transaction.set_namespace` at the beginn
 defmodule MyApp.CriticalJob do
   def run do
     # Configures this worker's jobs to report in the "critical" namespace
-    Appsignal.Transaction.set_namespace(:critical)
+    Appsignal.Span.set_namespace(Appsignal.Tracer.current_span(), "critical")
 
     # The actual worker code
   end


### PR DESCRIPTION
Update the documentation for AppSignal for Elixir 2.0. I've removed the old documentation here, but we might want to move it to a new place to keep them accessible. Removing them for now at least helped keep the documentation short and clear.