### PR TITLE
Add documentation for our StatsD (HTTP) endpoint on the public-endpoint

### DIFF
--- a/source/_side_nav.html.haml
+++ b/source/_side_nav.html.haml
@@ -259,6 +259,10 @@
         %li= link_with_active "Samples", "/api/samples.html"
         %li= link_with_active "Event names", "/api/event-names.html"
         %li= link_with_active "Sourcemaps", "/api/sourcemaps.html"
+        %li
+          = link_with_active "Public endpoint", "/api/public-endpoint/index.html"
+          %ul
+            = link_with_active "StatsD", "/api/public-endpoint/statsd.html"
 
   %ul
     %li.section

--- a/source/_side_nav.html.haml
+++ b/source/_side_nav.html.haml
@@ -260,7 +260,7 @@
         %li= link_with_active "Event names", "/api/event-names.html"
         %li= link_with_active "Sourcemaps", "/api/sourcemaps.html"
         %li
-          = link_with_active "Public endpoint", "/api/public-endpoint/index.html"
+          = link_with_active "Public endpoint", "/api/public-endpoint/"
           %ul
             = link_with_active "StatsD", "/api/public-endpoint/statsd.html"
 

--- a/source/api/public-endpoint/index.html.md
+++ b/source/api/public-endpoint/index.html.md
@@ -1,0 +1,42 @@
+---
+title: "Public endpoint"
+---
+
+## Public endpoint
+
+This API is a traffic-optimised endpoint to push data to AppSignal that is not sent through the agent.
+
+
+Base URL:
+
+```
+https://appsignal-endpoint.net
+```
+
+Authentication:
+
+Authentication is done with a Public endpoint (or Front-end) API key, which can be found under "App settings".
+
+URL Parameters:
+
+| Param | Type | Description  |
+| ------ | ------ | -----: |
+| api_key | string | **Front-end** API key, can be found under "App settings" |
+|  name  |  string  |   Name of the application, must match existing application on AppSignal|
+|  environment  |  string |  Environment of application, must match existing application/environment on AppSignal.  |
+
+
+Full example:
+
+```
+https://appsignal-endpoint.net/metrics/statsd?api_key=<api_key>&name=<name>&environment=<environment>
+```
+
+-> **Note**: This endpoint is optimised for traffic and does not validate the API key or payload, a `200`(`OK`) is returned when the body size is within the `200k` limit. This doesn't mean the request is accepted when processed.
+
+
+## Endpoints
+
+This API exposes the following endpoints:
+
+* [StatsD](/api/public-endpoint/statsd.html) Send (batched) StatsD-formatted metrics to AppSignal.

--- a/source/api/public-endpoint/index.html.md
+++ b/source/api/public-endpoint/index.html.md
@@ -2,29 +2,25 @@
 title: "Public endpoint"
 ---
 
-## Public endpoint
+This API is a traffic-optimized endpoint to push data to AppSignal that is not sent through the [AppSignal agent](/appsignal/how-appsignal-operates.html#agent).
 
-This API is a traffic-optimised endpoint to push data to AppSignal that is not sent through the agent.
-
-
-Base URL:
+## Base URL
 
 ```
 https://appsignal-endpoint.net
 ```
 
-Authentication:
+## Authentication
 
-Authentication is done with a Public endpoint (or Front-end) API key, which can be found under "App settings".
+Authentication is done with a Public endpoint (or Front-end) API key, which can be found in [App settings](https://appsignal.com/redirect-to/app?to=info).
 
-URL Parameters:
+## URL Parameters
 
-| Param | Type | Description  |
-| ------ | ------ | -----: |
-| api_key | string | **Front-end** API key, can be found under "App settings" |
-|  name  |  string  |   Name of the application, must match existing application on AppSignal|
-|  environment  |  string |  Environment of application, must match existing application/environment on AppSignal.  |
-
+| Parameters | Type | Description |
+| --- | ------ | --- |
+| api_key | String | **Front-end** API key, can be found in [App settings](https://appsignal.com/redirect-to/app?to=info). |
+| name | String | Name of the application, must match existing application on AppSignal. |
+| environment | String | Environment of application, must match existing application/environment on AppSignal. |
 
 Full example:
 
@@ -32,8 +28,7 @@ Full example:
 https://appsignal-endpoint.net/metrics/statsd?api_key=<api_key>&name=<name>&environment=<environment>
 ```
 
--> **Note**: This endpoint is optimised for traffic and does not validate the API key or payload, a `200`(`OK`) is returned when the body size is within the `200k` limit. This doesn't mean the request is accepted when processed.
-
+-> **Note**: This endpoint is optimized for large amounts of traffic and does not validate the API key or payload, a `200` (`OK`) response is returned when the body size is within the `200k` limit. This doesn't mean the request is accepted when received.
 
 ## Endpoints
 

--- a/source/api/public-endpoint/statsd.html.md
+++ b/source/api/public-endpoint/statsd.html.md
@@ -6,26 +6,28 @@ This StatsD API endpoint is provided to add additional metrics to AppSignal, whe
 
 This endpoint is meant for integrations that send aggregated metrics over a small period, it's preferred to send one request every 5 seconds with 100 metrics than 100 requests per 5 minutes with one metric each.
 
-Endpoint [POST]:
+## Endpoint
+
+Request method: `POST`
 
 | Endpoint | Description|
-| ------ | ------ |
-| **https://appsignal-endpoint.net/metrics/statsd** | Accepts (Dog)StatsD data |
+| --- | --- |
+| https://appsignal-endpoint.net/metrics/statsd | Accepts (Dog)StatsD data |
 
-URL Parameters:
+## URL parameters
 
-| Param | Type | Description  |
-| ------ | ------ | -----: |
-| api_key | string | **Front-end** API key, can be found under "App settings" |
-|  name  |  string  |   Name of the application, must match existing application on AppSignal|
-|  environment  |  string |  Environment of application, must match existing application/environment on AppSignal.  |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| api_key | String | **Front-end** API key, can be found in [App settings](https://appsignal.com/redirect-to/app?to=info). |
+| name | String | Name of the application, must match existing application on AppSignal. |
+| environment | String | Environment of application, must match existing application/environment on AppSignal. |
 
 
 ```
 https://appsignal-endpoint.net/metrics/statsd?api_key=<api_key>&name=<name>&environment=<environment>
 ```
 
-Body parameters:
+## Body parameters
 
 The post body should contain (Dog)statsD formatted metrics separated by a newline.
 
@@ -37,4 +39,4 @@ stripe_api_duration:19|ms|#function:payment,domain:appsignal
 cpu_usage:55.1|g|#hostname:frontend1,cpu:0
 ```
 
--> **Note**: This endpoint is optimised for traffic and does not validate the API key or payload, a `200`(`OK`) is returned when the body size is within the `200k` limit. This doesn't mean the request is accepted when processed.
+-> **Note**: This endpoint is optimized for large amounts of traffic and does not validate the API key or payload, a `200` (`OK`) response is returned when the body size is within the `200k` limit. This doesn't mean the request is accepted when received.

--- a/source/api/public-endpoint/statsd.html.md
+++ b/source/api/public-endpoint/statsd.html.md
@@ -1,0 +1,40 @@
+---
+title: "Public Endpoint - StatsD"
+---
+
+This StatsD API endpoint is provided to add additional metrics to AppSignal, where an existing integration can't be used or the language used isn't supported (yet).
+
+This endpoint is meant for integrations that send aggregated metrics over a small period, it's preferred to send one request every 5 seconds with 100 metrics than 100 requests per 5 minutes with one metric each.
+
+Endpoint [POST]:
+
+| Endpoint | Description|
+| ------ | ------ |
+| **https://appsignal-endpoint.net/metrics/statsd** | Accepts (Dog)StatsD data |
+
+URL Parameters:
+
+| Param | Type | Description  |
+| ------ | ------ | -----: |
+| api_key | string | **Front-end** API key, can be found under "App settings" |
+|  name  |  string  |   Name of the application, must match existing application on AppSignal|
+|  environment  |  string |  Environment of application, must match existing application/environment on AppSignal.  |
+
+
+```
+https://appsignal-endpoint.net/metrics/statsd?api_key=<api_key>&name=<name>&environment=<environment>
+```
+
+Body parameters:
+
+The post body should contain (Dog)statsD formatted metrics separated by a newline.
+
+For example:
+
+```
+login_count:1|c|#hostname:frontend1
+stripe_api_duration:19|ms|#function:payment,domain:appsignal
+cpu_usage:55.1|g|#hostname:frontend1,cpu:0
+```
+
+-> **Note**: This endpoint is optimised for traffic and does not validate the API key or payload, a `200`(`OK`) is returned when the body size is within the `200k` limit. This doesn't mean the request is accepted when processed.


### PR DESCRIPTION
[Do not merge yet, not deployed]

When deployed, documents our StatsD public endpoint, the first of a few that will make it easier to integrate AppSignal metrics with 3rd parties, not yet covered by our integrations (Ruby/Elixir/Node/Javascript etc.)