### PR TITLE
Add Security Content Policy docs

### DIFF
--- a/source/assets/stylesheets/modules/_article.sass
+++ b/source/assets/stylesheets/modules/_article.sass
@@ -85,6 +85,20 @@
       padding: 0
       margin: 0
 
+  blockquote
+    margin-bottom: 30px
+    background: $body-bg
+    padding: 20px
+    border-radius: $br
+
+    > p
+      margin-bottom: 20px
+      &:last-of-type
+        margin-bottom: 0
+    cite
+      display: block
+      text-align: right
+      color: $medium
   .notice
     color: rgba($dark,0.8)
     background: mix($blue,white,10%)

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -4,6 +4,7 @@ title: "Installing AppSignal for JavaScript"
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Installation](#installation)
   - [Supported browsers](#supported-browsers)
 - [Uninstall](#uninstall)
@@ -42,7 +43,7 @@ export default new Appsignal({
 
 Currently, we have no plans to supply a CDN-hosted version of this library.
 
-!> **NOTE:** If you are running a CDN in front of your assets, you'll need to make [two changes](/front-end/troubleshooting.html) for error reporting to be able to send errors to our API endpoint. Read more about the [required changes](/front-end/troubleshooting.html).
+!> **NOTE:** If you are running a CDN in front of your assets, you'll need to make [two changes](/front-end/troubleshooting.html) for error reporting to be able to send errors to our API endpoint. Read more about the [required changes](/front-end/troubleshooting.html). <br /><br />If you use Content Security Policy, make sure to add the correct headers as [described here](/front-end/troubleshooting.html#content-security-policy-csp).
 
 ### Supported browsers
 

--- a/source/front-end/troubleshooting.html.md
+++ b/source/front-end/troubleshooting.html.md
@@ -29,3 +29,25 @@ Or if you are using a Rails helper:
 ```ruby
 <%= javascript_include_tag "application", :crossorigin => :anonymous %>
 ```
+
+## Content Security Policy (CSP)
+
+Your Application's content Security Policy might prevent the error tracking library from sending data to our `https://appsignal-endpoint.net` endpoint.
+
+> Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement to distribution of malware.
+> <cite>[https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)</cite>
+
+Make sure to add `https://appsignal-endpoint.net` to your Content Security Policy header, if present.
+
+
+With just AppSignal in the header:
+
+```
+Content-Security-Policy: connect-src ‘self’ https://appsignal-endpoint.net
+```
+
+Or, with other content in the header:
+
+```
+Content-Security-Policy: <other_content>; connect-src ‘self’ https://appsignal-endpoint.net
+```

--- a/source/front-end/troubleshooting.html.md
+++ b/source/front-end/troubleshooting.html.md
@@ -10,7 +10,7 @@ Your app's assets are hosted on a CDN and you see the following warning message 
 Cross-domain or eval script error detected, error ignored
 ```
 
-This is normal browser behaviour and is a consequence of the [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy), a security measure designed to protect your users from [Cross-Site Request Forgery](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)) (CSRF) attacks. Luckily, this is a fairly easy problem to remedy.
+This is normal browser behaviour and is a consequence of the [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy), a security measure designed to protect your users from [Cross-Site Request Forgery](<https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)>) (CSRF) attacks. Luckily, this is a fairly easy problem to remedy.
 
 First, on your CDN, add a cross-origin (CORS) header:
 
@@ -38,7 +38,6 @@ Your Application's content Security Policy might prevent the error tracking libr
 > <cite>[https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)</cite>
 
 Make sure to add `https://appsignal-endpoint.net` to your Content Security Policy header, if present.
-
 
 With just AppSignal in the header:
 


### PR DESCRIPTION
When users send data from our front-end error handler, they need
to add our endpoint to the Security Content Policy headers, if applicable.

This section on the troubleshooting page describes how to add these headers
and which value to use.

@xadamy you can merge when approved :) 