### PR TITLE
update the usage with complete example

### DIFF
--- a/source/ruby/command-line/diagnose.html.md
+++ b/source/ruby/command-line/diagnose.html.md
@@ -53,6 +53,12 @@ On the command line in your project run:
 appsignal diagnose
 ```
 
+To run the diagnose on your production server, and send the report to AppSignal for support purposes, you can run the following command:
+
+```bash
+bundle exec appsignal diagnose --environment=production --send-report
+```
+
 ## Options
 
 | Option         | Description                            |


### PR DESCRIPTION
To make it easier for the customers to copy and paste the complete command required to run the diagnose tool and also send it to AppSignal for support.