### PR TITLE
remove table of content from the docs

### DIFF
--- a/source/api/markers.html.md
+++ b/source/api/markers.html.md
@@ -8,18 +8,6 @@ deploy using a "Deploy marker" or a custom event with a "Custom marker".
 This Marker endpoint allows the creation and indexing of markers that are
 available per application.
 
-## Table of Contents
-
-- [Marker types](#marker-types)
-  - [Deploy markers](#deploy-markers)
-  - [Custom markers](#custom-markers)
-- Endpoints
-  - [Marker create - POST markers.json](#marker-create)
-  - [Marker index - GET markers.json](#marker-index)
-  - [Marker show - GET markers/[marker_id].json](#marker-show)
-  - [Marker update - PUT markers.json](#marker-update)
-  - [Marker delete - DELETE markers.json](#marker-delete)
-
 ## Marker types
 
 ### Deploy markers

--- a/source/api/sourcemaps.html.md
+++ b/source/api/sourcemaps.html.md
@@ -6,14 +6,6 @@ Sourcemaps are used to get the original line and column number from a minified b
 
 This API provides an easy way to upload private sourcemaps for use with [frontend errors](/front-end/sourcemaps.html).
 
-## Table of Contents
-
-- Endpoints
-  - [Sourcemap create - POST sourcemaps](#sourcemap-create)
-      - [Parameters](#parameters)
-      - [Responses](#responses)
-      - [Example](#example)
-
 ## Sourcemap create
 
 This endpoint enables the creation of private sourcemaps.

--- a/source/application/anomaly-detection/index.html.md
+++ b/source/application/anomaly-detection/index.html.md
@@ -8,16 +8,6 @@ Anomaly detection works by detecting changes in metric values on a minutely basi
 
 Sometimes it's good to know immediately when a threshold is reached, at other times it may be good to wait a few minutes before alerting you. For this you can use [warm-ups and cooldowns](#warm-up-and-cooldown).
 
-## Table of Contents
-
-- [Alert states](#alert-states)
-- [Triggers](#setting-up-triggers)
-  - [Editing triggers](#editing-triggers)
-- [Warm-up and cooldown](#warm-up-and-cooldown)
-  - [Warm-up](#warm-up)
-  - [Cooldown](#cooldown)
-- [Data processing](#data-processing)
-
 ## Alert states
 
 Alerts can have four different states:

--- a/source/application/data-collection.html.md
+++ b/source/application/data-collection.html.md
@@ -6,18 +6,6 @@ By default AppSignal gathers relevant data for errors and performance measuremen
 
 You can configure AppSignal to gather more, or less, information than it does by default by tagging your transactions and configuring the request headers, parameter filtering, etc. Ideally we receive as little metadata for samples as possible, and only data that is needed to debug an exception or performance issue.
 
-
-## Table of Contents
-
-- [Ignore actions](#ignore-actions)
-- [Ignore errors](#ignore-errors)
-- [Request headers](#request-headers)
-- [Parameters](#parameters)
-- [Session data](#session-data)
-- [Tagging](#tagging)
-- [Namespaces](#namespaces)
-- [Queries](#queries)
-
 ## Ignore actions
 
 Noisy actions (web endpoints, background jobs, scheduled tasks) sometimes do more harm than good. To filter out these actions it's possible to ignore them in AppSignal by updating the AppSignal configuration in an app.

--- a/source/application/index.html.md
+++ b/source/application/index.html.md
@@ -6,22 +6,6 @@ Applications (previously known as "sites", also referred to as "apps") are Ruby,
 
 A list of Applications appears on the [Application index] and in the application quick switcher. Every application has a parent [organization](/organization/index.html), which can have multiple applications. (Exception: Organizations created by the Heroku add-on only support one application.)
 
-## Table of Contents
-
-- [Adding applications](#adding-applications)
-- [Environments](#environments)
-- [Namespaces](namespaces.html)
-- [Markers](markers/)
-  - [Deploy markers](markers/deploy-markers.html)
-  - [Custom markers](markers/custom-markers.html)
-- [Settings](settings.html)
-- [Incident notification settings](notification-settings.html)
-- [Link templates](link-templates.html)
-- [Backtrace links](backtrace-links.html)
-- [Integrations (full list)](integrations/)
-- [Running multiple applications on one host](#running-multiple-applications-on-one-host)
-- [Removing an application](#removing-an-application)
-
 ## Adding applications
 
 To add a new Application to AppSignal, please follow the [add a new application setup wizard](/application/new-application.html).

--- a/source/application/integrations/webhooks.html.md
+++ b/source/application/integrations/webhooks.html.md
@@ -8,13 +8,7 @@ To receive a webhook, go to the "Notifications" tab the site's sidebar, click th
 
 ![Webhook](/assets/images/screenshots/app_webhook.png)
 
-## Table of Contents
-
 There are multiple webhooks available. Which payloads the webhook receives can be configured in the configuration form for the webhook as seen in the screenshot above.
-
-- [Deploy markers](#deploy-markers)
-- [Exception incidents](#exception-incidents)
-- [Performance incidents](#performance-incidents)
 
 ## Deploy markers
 

--- a/source/application/link-templates.html.md
+++ b/source/application/link-templates.html.md
@@ -7,12 +7,6 @@ AppSignal supports tagging of requests, as described in our tagging guides for
 to generate URLs to your own application to deep link to pages in your own
 system, such as related user profiles or blog posts.
 
-## Table of contents
-
-- [Tagging requests](#tagging-requests)
-- [Creating a link template](#creating-a-link-template)
-  - [Customizing link names](#customizing-link-names)
-
 ## Tagging requests
 
 For link templates to work AppSignal needs to have the data necessary to create

--- a/source/application/markers/custom-markers.html.md
+++ b/source/application/markers/custom-markers.html.md
@@ -15,12 +15,6 @@ See also our announcement posts about Custom markers:
 - [Introducing custom markers](http://blog.appsignal.com/2016/10/28/custom-markers.html)
 - [Add custom markers from any graph](http://blog.appsignal.com/2016/11/28/custom-markers-from-any-graph.html)
 
-## Table of Contents
-
-- [Creating a custom marker](#creating-a-custom-marker)
-  - [Using the Graph UI](#using-the-graph-ui)
-  - [Using the AppSignal API](#using-the-appsignal-api)
-
 ## Creating a custom marker
 
 A custom marker can be created in two ways. Through the UI on AppSignal.com on

--- a/source/application/markers/deploy-markers.html.md
+++ b/source/application/markers/deploy-markers.html.md
@@ -10,18 +10,6 @@ When a new deploy is detected, the list of incidents is empty for the newest dep
 
 ![Deploy markers in samples list](/assets/images/screenshots/app_incident_samples_list.png)
 
-## Table of Contents
-
-- [Table of Contents](#table-of-contents)
-- [Deploy methods](#deploy-methods)
-- [Revision config option](#revision-config-option)
-  - [Config option](#config-option)
-  - [System environment variable](#system-environment-variable)
-  - [Heroku support](#heroku-support)
-  - [Cloud66 Support](#cloud66-support)
-- [Manually create a Deploy marker](#manually-create-a-deploy-marker)
-  - [Ruby CLI tool](#ruby-cli-tool)
-
 ## Deploy methods
 
 There are two methods of notifying AppSignal of a new deploy. These two methods cannot be used together.

--- a/source/application/markers/index.html.md
+++ b/source/application/markers/index.html.md
@@ -13,7 +13,3 @@ Custom markers can be used for anything from scaling operations, to sudden
 spikes in traffic and infrastructure issues such as when a database was acting
 up.
 
-## Table of Contents
-
-- [Deploy markers](deploy-markers.html)
-- [Custom markers](custom-markers.html)

--- a/source/application/notification-settings.html.md
+++ b/source/application/notification-settings.html.md
@@ -6,16 +6,6 @@ Whenever AppSignal detects a new error or performance measurement, we open an in
 
 AppSignal can send out notifications whenever a new incident, or new instances of an already existing incident, is detected. Notifications can happen by email or by one of our [many notifiers](/application/integrations/).
 
-## Table of Contents
-
-- [Notification options](#notification-options)
-- [Error incident notification options](#notification-options)
-- [Performance incident notification options](#notification-options)
-- [Organization and app namespace defaults](#organization-and-app-namespace-defaults)
-  - [App notification defaults](#app-notification-defaults)
-  - [Organization notification defaults](#organization-notification-defaults)
-  - [Notification defaults inheritance](#notification-defaults-inheritance)
-
 ## Notification options
 
 Whenever a new incident gets created it will inherit the [app's notification defaults](#app-notification-defaults). When an [Error](#error-incident-notification-settings) or [Performance](#performance-incident-notification-settings) incident has been created, its notification settings can be changed on the incident page itself.

--- a/source/appsignal/contributing/index.html.md
+++ b/source/appsignal/contributing/index.html.md
@@ -11,16 +11,6 @@ questions about contributing to any of our projects.
 We're very happy sending anyone who contributes Stroopwaffles. Have look at
 everyone we sent a package to so far on our [Stroopwaffles page][waffles-page].
 
-## Table of Contents
-
-- [Open Source projects](#open-source-projects)
-- [Using git and GitHub](#using-git-and-github)
-- [Versioning](#versioning)
-- [Reporting bugs](#reporting-bugs)
-- [Feature requests](#feature-requests)
-- [Security issues](#security-issues)
-- [Code of Conduct][coc]
-
 ## Open Source projects
 
 All open source projects are available on our [AppSignal GitHub organization][github-appsignal].

--- a/source/appsignal/data-life-cycle.html.md
+++ b/source/appsignal/data-life-cycle.html.md
@@ -8,17 +8,6 @@ AppSignal is eventually consistent. This means that, even though we try to minim
 
 Requests that are sent later than others will appear first in AppSignal.com. By breaking down the process we can tell you why this happens.
 
-## Table of Contents
-
-- [Language libraries](#language-libraries)
-- [Push API](#push-api)
-- [Processing](#processing)
-  - [Anomaly detection](#anomaly-detection)
-    - [Transmitting the data](#transmitting-the-data)
-    - [Clock drift on app servers](#clock-drift-on-app-servers)
-    - [Processing of metrics data](#processing-of-metrics-data)
-- [Conclusion](#conclusion)
-
 ## Language libraries
 
 The AppSignal language libraries ([Ruby](/ruby), [Elixir](/elixir), [JavaScript for Front-end](/front-end)) collect transaction and metrics data. [Transactions](/appsignal/terminology.html#transactions) are HTTP requests, background jobs and other custom transactions. Metrics data is based on the transaction data but can also be set using our [custom metrics](/metrics/custom.html).

--- a/source/elixir/command-line/demo.html.md
+++ b/source/elixir/command-line/demo.html.md
@@ -10,15 +10,6 @@ Read more about how to use the demonstration command on the [Debugging][debuggin
 
 This tool is available since version 0.11.0 of the AppSignal for Elixir package.
 
-## Table of Contents
-
-- [Usage](#usage)
-  - [With a specific environment](#with-a-specific-environment)
-  - [With a release binary](#with-a-release-binary)
-- [Options](#options)
-  - [Environment option](#options)
-- [Exit codes](#exit-codes)
-
 ## Usage
 
 On the command line in your project run:

--- a/source/elixir/command-line/diagnose.html.md
+++ b/source/elixir/command-line/diagnose.html.md
@@ -6,21 +6,6 @@ The AppSignal for Elixir package ships with a self diagnostic tool. This tool ca
 
 This tool has been available since version `0.12.0` of the AppSignal for Elixir package.
 
-## Table of Contents
-
-- [The diagnostic report](#the-diagnostic-report)
-- [Submitting the report](#submitting-the-report)
-- [Usage](#usage)
-  - [With an Elixir release binary](#with-an-elixir-release-binary)
-  - [With a release binary](#with-a-release-binary)
-- [Options](#options)
-  - [Environment option](#environment-option)
-  - [Report submission option](#report-submission-option)
-- [Configuration output format](#configuration-output-format)
-  - [Configuration option values format](#configuration-option-values-format)
-  - [Configuration sources](#configuration-sources)
-- [Exit codes](#exit-codes)
-
 ## The diagnostic report
 
 This command line tool is useful when testing AppSignal on a system and validating the local configuration. It outputs useful information to debug issues and it checks if AppSignal agent is able to run on the machine's architecture and communicate with the AppSignal servers.

--- a/source/elixir/command-line/install.html.md
+++ b/source/elixir/command-line/install.html.md
@@ -5,13 +5,6 @@ description: "Command line tool to install AppSignal in an Elixir application. D
 
 Command line tool to install AppSignal in an Elixir application.
 
-## Table of Contents
-
-- [Description](#description)
-- [Configuration methods](#configuration-methods)
-- [Usage](#usage)
-- [Exit codes](#exit-codes)
-
 The command line tool is primarily used to help set up the configuration for AppSignal. Please follow the [installation guide](/application/new-application.html) when adding a new application to AppSignal.
 
 After the configuration/installation is completed the installer perform the [demonstration](demo.html) command line tool and sends demo data to AppSignal servers to help with the installation wizard.

--- a/source/elixir/configuration/ignore-actions.html.md.erb
+++ b/source/elixir/configuration/ignore-actions.html.md.erb
@@ -4,11 +4,6 @@ title: "Ignore actions"
 
 <%= partial "shared/ignore_actions" %>
 
-## Table of Contents
-
-- [Ignore by action name](#ignore-by-action-name)
-- [Ignore by namespace](/elixir/instrumentation/namespaces.html#ignore-by-namespace) - Namespace documentation
-
 ## Ignore by action name
 
 Also see the [`ignore_actions`](/elixir/configuration/options.html#option-ignore_actions) configuration option documentation for more about this configuration option.

--- a/source/elixir/configuration/index.html.md
+++ b/source/elixir/configuration/index.html.md
@@ -8,19 +8,6 @@ know which application it's instrumenting or in which environment.
 On this topic we'll explain how to configure AppSignal, what can be configured
 in the Elixir package and what the minimal configuration needed is.
 
-## Table of Contents
-
-- [Minimal required configuration](#minimal-required-configuration)
-- [Configuration options](/elixir/configuration/options.html)
-  - [Ignore actions](/elixir/configuration/ignore-actions.html)
-  - [Ignore errors](/elixir/configuration/ignore-errors.html)
-  - [Parameter filtering](/elixir/configuration/parameter-filtering.html)
-  - [Session data filtering](/elixir/configuration/session-data-filtering.html)
-- [Application environments](#application-environments)
-  - [Disable AppSignal for tests](#disable-appsignal-for-tests)
-- [Application versions](#application-versions)
-- [Example configuration](#example-configuration)
-
 ## Minimal required configuration
 
 The minimal required configuration needed by AppSignal for Elixir are the

--- a/source/elixir/configuration/parameter-filtering.html.md.erb
+++ b/source/elixir/configuration/parameter-filtering.html.md.erb
@@ -8,13 +8,6 @@ We support two ways of filtering parameters from being sent to AppSignal. Either
 
 !> **Warning**: Do not send personal data to AppSignal. If your parameters or session data contain personal data, please use filtering to avoid sending this data to AppSignal.
 
-## Table of Contents
-
-- [AppSignal parameter filtering](#appsignal-parameter-filtering)
-    - [Processor parameter filtering](#processor-parameter-filtering)
-- [Phoenix's filter_parameters configuration](#phoenix-filter_parameters-configuration)
-- [Filter all parameters](#filter-all-parameters)
-
 ## AppSignal parameter filtering
 
 If you're not using Phoenix, or want to filter parameters without changing the Phoenix.Logger's configuration,

--- a/source/elixir/configuration/session-data-filtering.html.md
+++ b/source/elixir/configuration/session-data-filtering.html.md
@@ -11,11 +11,6 @@ In Rails applications AppSignal automatically stores the contents of the user's 
 
 -> This feature is available since AppSignal Elixir package [version 1.6.0](https://blog.appsignal.com/2018/05/08/elixir-integration-1-6.html).
 
-## Table of Contents
-
-- [AppSignal session data filtering](#appsignal-session-data-filtering)
-- [Skip sending session data](#skip-sending-session-data)
-
 ## AppSignal session data filtering
 
 Session data filtering will filter out any values from specified keys in the [`filter_session_data`](/elixir/configuration/options.html#option-filter_session_data) configuration option. Any filtered out value will be replaced with `[FILTERED]` before it leaves your application and is send to the AppSignal servers. This means that AppSignal never receives any of the filtered data.

--- a/source/elixir/index.html.md
+++ b/source/elixir/index.html.md
@@ -7,13 +7,6 @@ package][appsignal-package]. The package supports pure Elixir applications and
 the Phoenix framework out-of-the-box. Other frameworks and packages might
 require some [custom instrumentation](/elixir/instrumentation/index.html).
 
-## Table of Contents
-
-- [Installation](/elixir/installation.html) - start here
-- [Configuration](/elixir/configuration/index.html)
-- [Integrating with Phoenix](/elixir/integrations/phoenix.html)
-- [Instrumentation](/elixir/instrumentation/index.html)
-
 ## Installation
 
 To get started with AppSignal for Elixir, follow our guide to [installing

--- a/source/elixir/installation/index.html.md
+++ b/source/elixir/installation/index.html.md
@@ -4,17 +4,6 @@ title: "Installing AppSignal for Elixir"
 
 Please follow the [installation guide](/application/new-application.html) when adding a new application to AppSignal.
 
-## Table of Contents
-
-- [Installation](#installation)
-  - [Requirements](#requirements)
-  - [Configuration](#configuration)
-      - [Manual configuration](#manual-configuration)
-  - [Run your application!](#run-your-application)
-  - [Optional: Add Phoenix instrumentation](#optional-add-phoenix-instrumentation)
-  - [Optional: Add custom instrumentation](#optional-add-custom-instrumentation)
-- [Uninstall](#uninstall)
-
 ## Installation
 
 Installing the AppSignal package in your Elixir application requires a couple manual steps. Currently pure Elixir applications and the Phoenix framework are supported. Both use-cases are described in this guide.

--- a/source/elixir/instrumentation/exception-handling.html.md
+++ b/source/elixir/instrumentation/exception-handling.html.md
@@ -12,12 +12,6 @@ To avoid these errors from being raised as problems in AppSignal it's possible
 to add exception handling to your code or even let AppSignal completely ignore
 certain errors.
 
-## Table of Contents
-
-- [Ignore errors](#ignore-errors)
-- [Appsignal.Transaction.set_error/3](#appsignal-transaction-set_error-3)
-- [Appsignal.send_error/6](#appsignal-send_error-6)
-
 ## Ignore errors
 
 The AppSignal configuration makes it possible to [ignore

--- a/source/elixir/instrumentation/index.html.md
+++ b/source/elixir/instrumentation/index.html.md
@@ -5,10 +5,3 @@ title: "Custom instrumentation for Elixir"
 AppSignal provides many ways to bring more insights in your application by
 adding more instrumentation or tagging the data that appears in the UI at
 AppSignal.com.
-
-## Table of Contents
-
-- [Integrating AppSignal](/elixir/instrumentation/integrating-appsignal.html)
-- [Add instrumentation](/elixir/instrumentation/instrumentation.html)
-- [Exception handling](/elixir/instrumentation/exception-handling.html)
-- [Tagging](/elixir/instrumentation/tagging.html)

--- a/source/elixir/instrumentation/instrumentation.html.md
+++ b/source/elixir/instrumentation/instrumentation.html.md
@@ -25,24 +25,6 @@ package](https://hexdocs.pm/appsignal/).
    your code. To track errors please read our
    [exception handling](/elixir/instrumentation/exception-handling.html) guide.
 
-## Table of Contents
-
-- [Function decorators](#function-decorators)
-  - [Transaction events](#decorator-transaction-events)
-  - [Transactions](#decorator-transactions)
-  - [Namespaces](#decorator-namespaces)
-      - [Custom namespaces](#decorator-custom-namespaces)
-  - [Phoenix channels](#decorator-phoenix-channels)
-- [Instrumentation helper functions](#instrumentation-helper-functions)
-  - [Instrument helper](#helper-instrument-helper)
-      - [Adding asynchronous events to a transaction](#adding-asynchronous-events-to-a-transaction)
-  - [Transactions](#helper-transactions)
-  - [Transaction metadata](#helper-transaction-metadata)
-  - [Namespaces](#helper-namespaces)
-      - [Custom namespaces](#helper-custom-namespaces)
-  - [Exception handling](#helper-exception-handling)
-  - [Example](#helper-example)
-
 ## Function decorators
 
 Using the `Appsignal.Instrumentation.Decorators` decorator module, it's

--- a/source/elixir/instrumentation/minutely-probes.html.md
+++ b/source/elixir/instrumentation/minutely-probes.html.md
@@ -8,17 +8,6 @@ By default the AppSignal Elixir package enables a probe for the ErlangVM.
 
 -> **Note**: We recommend using AppSignal Elixir package `1.10.1` and up when using this feature.
 
-## Table of Contents
-
-- [Usage](#usage)
-  - [Multiple instances](#multiple-instances)
-- [Configuration](#configuration)
-- [Creating probes](#creating-probes)
-  - [Anonymous function](#anonymous-function)
-  - [Module based function](#module-based-function)
-- [Registering probes](#registering-probes)
-- [Overriding default probes](#overriding-default-probes)
-
 ## Usage
 
 The minutely probes allow the AppSignal Elixir package to collect [custom metrics](/metrics/custom.html) by default for the ErlangVM and app-specific metrics by [creating your own probe](#creating-probes).

--- a/source/elixir/integrations/erlang.html.md
+++ b/source/elixir/integrations/erlang.html.md
@@ -4,11 +4,6 @@ title: "Erlang"
 
 The AppSignal for Elixir package integrates with the Erlang VM to provide metrics not just about your app but the virtual machine it's running in.
 
-## Table of Contents
-
-- [Minutely probe](#minutely-probe)
-  - [Configuration](#minutely-probe-configuration)
-
 ## Minutely probe
 
 Since AppSignal Elixir package `1.10.1` and up a [minutely probe](/elixir/instrumentation/minutely-probes.html) is activated by default. Once we detect these metrics we'll add a [magic dashboard](https://blog.appsignal.com/2019/03/27/magic-dashboards.html) to your apps.

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -13,21 +13,6 @@ instrumentation](/elixir/instrumentation/index.html) documentation.
 More information can be found in the [AppSignal Hex package
 documentation][hex-appsignal].
 
-## Table of Contents
-
-- [Table of Contents](#table-of-contents)
-- [Incoming HTTP requests](#incoming-http-requests)
-- [Phoenix instrumentation hooks](#phoenix-instrumentation-hooks)
-- [Template rendering](#template-rendering)
-- [Queries](#queries)
-- [Channels](#channels)
-  - [Channel instrumentation with a channel's handle](#channel-instrumentation-with-a-channels-handle)
-  - [Channel instrumentation without decorators](#channel-instrumentation-without-decorators)
-  - [Adding channel payloads](#adding-channel-payloads)
-- [LiveView](#liveview)
-- [Instrumentation for included Plugs](#instrumentation-for-included-plugs)
-- [Custom instrumentation](#custom-instrumentation)
-
 ## Incoming HTTP requests
 
 To start logging HTTP requests in your Phoenix app, make sure you use the

--- a/source/elixir/integrations/plug.html.md
+++ b/source/elixir/integrations/plug.html.md
@@ -16,12 +16,6 @@ instrumentation](/elixir/instrumentation/index.html) documentation.
 More information can be found in the [AppSignal Hex package
 documentation][hex-appsignal].
 
-## Table of Contents
-
-- [Incoming HTTP requests](#incoming-http-requests)
-- [Custom instrumentation](#custom-instrumentation)
-- [Instrumentation for included Plugs](#instrumentation-for-included-plugs)
-
 ## Incoming HTTP requests
 
 We'll start out with a small Plug app that accepts `GET` requests to `/` and

--- a/source/front-end/breadcrumbs.html.md
+++ b/source/front-end/breadcrumbs.html.md
@@ -4,12 +4,7 @@ title: "Breadcrumbs"
 
 When debugging an issue in a UI, it can be useful to know what events occurred in the build up to the error being thrown. Breadcrumbs are a time-ordered list of events in your application, that is filled as a user traverses your application, and is sent along with a `Span` whenever an error is caught by the library. This allows you to gather information that is useful for reproducing tricky-to-debug errors by re-tracing a user's path through your application.
 
-## Table of Contents
-
-- [Usage](#usage)
-- [Plugins](#plugins)
-
-    ![Breadcrumbs](/assets/images/screenshots/frontend/breadcrumbs.svg)
+![Breadcrumbs](/assets/images/screenshots/frontend/breadcrumbs.svg)
 
 ## Usage
 

--- a/source/front-end/index.html.md
+++ b/source/front-end/index.html.md
@@ -4,25 +4,6 @@ title: "AppSignal for JavaScript"
 
 AppSignal has amazing support for catching errors from front-end JavaScript applications and sending them to AppSignal. An `npm` library for catching JavaScript errors is available for that.
 
-## Table of Contents
-
-- [Installation](/front-end/installation.html)
-- [Configuration](/front-end/configuration/)
-- [Error handling](/front-end/error-handling.html)
-- [Creating and Using a Span](/front-end/span.html)
-- [Hooks](/front-end/hooks.html)
-- [Sourcemaps](/front-end/sourcemaps.html)
-- [Integrations](/front-end/integrations/)
-  - [React](/front-end/integrations/react.html)
-  - [Vue](/front-end/integrations/vue.html)
-  - [Angular](/front-end/integrations/angular.html)
-  - [Ember](/front-end/integrations/ember.html)
-  - [Preact](/front-end/integrations/preact.html)
-  - [Stimulus](/front-end/integrations/stimulus.html)
-- [Plugins](/front-end/plugins/)
-  - [plugin-window-events](/front-end/plugins/plugin-window-events.html)
-  - [plugin-path-decorator](/front-end/plugins/plugin-path-decorator.html)
-
 !> **NOTE:** Uncaught exceptions are **not** captured by default. [Read this section to find out why](/front-end/error-handling.html#uncaught-exceptions). You can enable this functionality by enabling the [`plugin-window-events`](/front-end/plugins/plugin-window-events.html) plugin.
 
 ## Creating a Push API Key

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -2,13 +2,6 @@
 title: "Installing AppSignal for JavaScript"
 ---
 
-## Table of Contents
-
-- [Table of Contents](#table-of-contents)
-- [Installation](#installation)
-  - [Supported browsers](#supported-browsers)
-- [Uninstall](#uninstall)
-
 ## Installation
 
 First, add the `@appsignal/javascript` package to your `package.json`. Then, run `yarn install`/`npm install`. You'll also need a Push API key from the ["Push and deploy" section](https://appsignal.com/redirect-to/app?to=info) of your App settings page.

--- a/source/front-end/sourcemaps.html.md.erb
+++ b/source/front-end/sourcemaps.html.md.erb
@@ -5,12 +5,6 @@ title: "Sourcemaps <sup>Beta</sup>"
 Sourcemaps are a way to convert (minified) JavaScript backtraces such as `https://your.host/application-minified.js:53:9895
 ` to something a bit more helpful. A sourcemap contains data about your front-end source code and given the minified file, line number and column number, we can ask a sourcemap for the original function, line/column number and even surrounding source code.
 
-## Table of Contents
-
-- [Requirements](#requirements)
-- [Public sourcemaps](#public-sourcemaps)
-- [Private sourcemaps](#private-sourcemaps)
-
 ## Requirements
 
 Enhancing backtraces with sourcemaps has one requirement:

--- a/source/metrics/custom.html.md
+++ b/source/metrics/custom.html.md
@@ -14,18 +14,6 @@ For more information about how dashboards and graphs use metrics data, see our [
 
 -> **Note**: This feature was introduced with the `1.0` version of the AppSignal for Ruby gem. It is also available in other AppSignal integrations such as Elixir and Node.js.
 
-## Table of Contents
-
-- [Metric types](#metric-types)
-  - [Gauge](#gauge)
-  - [Measurement](#measurement)
-  - [Counter](#counter)
-- [Metric naming](#metric-naming)
-- [Metric values](#metric-values)
-    - [Value formatting](#metric-values-value-formatting)
-        - [File size](#metric-values-file-size)
-- [Metric tags](#metric-tags)
-
 ## Metric types
 
 There are three types of metrics we collect, each with their own purpose.

--- a/source/metrics/dashboards.html.md
+++ b/source/metrics/dashboards.html.md
@@ -9,11 +9,6 @@ This page provides more detailed information about how some dashboard graphs opt
 
 [Open the dashboard and graph builder](https://appsignal.com/redirect-to/app?to=dashboard&overlay=dashboardForm) in your app.
 
-## Table of Contents
-
-- [Graphs types](#graphs-types)
-- [NULL values](#null-values)
-
 ## Graphs types
 
 Some data is better understood if the graph is rendered in a different way. We provide three display options:

--- a/source/metrics/host-metrics/containers.html.md
+++ b/source/metrics/host-metrics/containers.html.md
@@ -10,12 +10,6 @@ Host metrics for containerized systems are fully supported since AppSignal for R
 
 -> **Note**: This page is part of the [host metrics section](/metrics/host.html).
 
-## Table of Contents
-
-- [Container limits](#container-limits)
-- [Supported metrics](#supported-metrics)
-  - [About CPU metrics](#cpu-metrics)
-
 ## Container limits
 
 For container host metrics to be accurate, limits need to be set for every container. This means, configuring your container to have a limited number of CPUs and memory allocated to it. Without these limits the container reports the maximum possible value of these metrics, resulting in the host reporting Terabytes of available memory for example. A container without swap configured, or unsupported on the host system, will report a `0` value. For more information on how to limit your container's CPU and memory, please read the documentation on:

--- a/source/metrics/host-metrics/index.html.md
+++ b/source/metrics/host-metrics/index.html.md
@@ -16,13 +16,6 @@ For a preview of how host metrics look in the AppSignal interface, please see ou
 -> </ul>
 -> A list of supported Operating Systems is available on the [Supported Operating Systems](/support/operating-systems.html) page.
 
-## Table of Contents
-
-- [Collected host metrics](#collected-host-metrics)
-- [Heroku support][heroku support]
-- [Docker/container support][container support]
-- [Dokku support](#dokku-support)
-
 ## Collected host metrics
 
 The following host metrics are collected by the AppSignal agent for every minute on your system.

--- a/source/nodejs/command-line/diagnose.html.md
+++ b/source/nodejs/command-line/diagnose.html.md
@@ -4,19 +4,6 @@ title: "AppSignal for Node.js: Diagnose tool"
 
 The AppSignal Node.js package ships with a self diagnostic tool. This tool can be used to debug your AppSignal installation and is one of the first thing our support team asks for when there's an issue.
 
-## Table of Contents
-
-- [The diagnostic report](#the-diagnostic-report)
-- [Submitting the report](#submitting-the-report)
-- [Usage](#usage)
-- [Options](#options)
-  - [Environment option](#environment-option)
-  - [Report submission option](#report-submission-option)
-- [Configuration output format](#configuration-output-format)
-  - [Configuration option values format](#configuration-option-values-format)
-  - [Configuration sources](#configuration-sources)
-- [Exit codes](#exit-codes)
-
 ## The diagnostic report
 
 This command line tool is useful when testing AppSignal on a system and validating the local configuration. It outputs useful information to debug issues and it checks if AppSignal agent is able to run on the machine's architecture and communicate with the AppSignal servers.

--- a/source/nodejs/configuration/index.html.md
+++ b/source/nodejs/configuration/index.html.md
@@ -4,13 +4,6 @@ title: "AppSignal for Node.js configuration"
 
 In this section, we'll explain how to configure AppSignal, what can be configured in the Node.js package, and what the minimal configuration needed is.
 
-## Table of Contents
-
-- [Minimal required configuration](#minimal-required-configuration)
-- [Configuration options](/nodejs/configuration/options.html)
-- [Application environments](#application-environments)
-  - [Disable AppSignal for tests](#disable-appsignal-for-tests)
-
 ## Minimal required configuration
 
 The minimal required configuration needed by AppSignal for Node.js are the following items. If they are not present, AppSignal will not send any data to AppSignal.com.

--- a/source/nodejs/index.html.md
+++ b/source/nodejs/index.html.md
@@ -10,14 +10,6 @@ The new Node.js implementation contains some concepts that vary from the Ruby an
 
 -> **Note**: AppSignal for Node.js is currently under active development.
 
-## Table of Contents
-
-- [Installation][installation]
-- [Configuration][configuration]
-- [Tracing][tracing]
-- [Metrics][metrics]
-- [Integrations][integrations]
-
 ## Supported versions
 
 Our Node.js suppport tracks the active LTS release and above, which is currently [v10](https://github.com/nodejs/Release) and above.

--- a/source/nodejs/metrics/index.html.md
+++ b/source/nodejs/metrics/index.html.md
@@ -7,9 +7,3 @@ To track application-wide metrics, you can send custom metrics to AppSignal. The
 With different [types of metrics](#metric-types) (gauges, counters and measurements) you can track any kind of data from your apps and [tag](#metric-tags) them with metadata to easily spot the differences between contexts.
 
 ![Custom metrics demo dashboard](/assets/images/screenshots/custom_metrics_dashboard.png)
-
-
-## Table of Contents
-
-- [The Metrics object](/nodejs/metrics/meters.html)
-- [Minutely probes](/nodejs/metrics/minutely-probes.html)

--- a/source/nodejs/metrics/meters.html.md
+++ b/source/nodejs/metrics/meters.html.md
@@ -2,16 +2,6 @@
 title: "The Metrics object"
 ---
 
-## Table of Contents
-
-- [Metric types](#metric-types)
-  - [Gauge](#gauge)
-  - [Measurement](#measurement)
-  - [Counter](#counter)
-- [Metric naming](#metric-naming)
-- [Metric values](#metric-values)
-- [Metric tags](#metric-tags)
-
 ## Metric types
 
 There are three types of metrics we collect all with their own purpose.

--- a/source/nodejs/tracing/index.html.md
+++ b/source/nodejs/tracing/index.html.md
@@ -7,10 +7,3 @@ AppSignal provides many ways to provide more insights in your application - by a
 **Traces** are made of one or many `Span`s. A Trace can be thought of as a _directed acyclic graph (DAG)_ of `Span`s:
 
 ![Trace diagram](/assets/images/abstract-trace.png)
-
-## Table of Contents
-
-- [The Tracer object](/nodejs/tracing/tracer.html)
-- [Async tracing and Scopes](/nodejs/tracing/scopes.html)
-- [Creating and using a Span](/nodejs/tracing/span.html)
-- [Span API](/nodejs/tracing/span-api.html)

--- a/source/nodejs/tracing/span.html.md
+++ b/source/nodejs/tracing/span.html.md
@@ -6,13 +6,6 @@ A `Span` is the name of the object that we use to capture data about your applic
 
 It is designed to closely follow the concept of a Span from the [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification) standard specification, but there are some minor differences that we'll get into later.
 
-## Table of Contents
-
-- [Creating a new `Span`](#creating-a-new-span)
-- [Naming a `Span`](#naming-a-span)
-- [Updating a `Span`](#updating-a-span)
-- [`Span` API](#span-api)
-
 ## Creating a new `Span`
 
 A `Span` can be created by calling `tracer.createSpan()`, which initializes a new `Span` object.

--- a/source/nodejs/tracing/tracer.html.md
+++ b/source/nodejs/tracing/tracer.html.md
@@ -6,11 +6,6 @@ AppSignal for Node.js contains a new concept that is different to the current Ru
 
 The Tracer is responsible for tracking the currently active `Span`, and exposes functions for creating and activating new `Span`s.
 
-## Table of Contents
-
-- [Retrieving the `Tracer`](#retrieving-the-tracer)
-- [Retrieving the current `Span`](#retrieving-the-current-span)
-
 ## Retrieving the `Tracer`
 
 ```js

--- a/source/organization/index.html.md
+++ b/source/organization/index.html.md
@@ -6,14 +6,6 @@ Let's say you have your own startup but still do some freelance work for clients
 
 Organizations are basically umbrellas for your applications, which we charge on the organization level.
 
-## Table of Contents
-
-- [Creating a new organization](#creating-a-new-organization)
-- [Renaming an organization](#renaming-an-organization)
-- [Leaving an organization](#leaving-an-organization)
-- [Team management](/organization/team)
-- [Billing](/organization/billing.html)
-
 ## Creating a new organization
 
 Once you sign up for an AppSignal account you will need to create an Organization, except when you accept an invitation to another organization.

--- a/source/ruby/command-line/demo.html.md
+++ b/source/ruby/command-line/demo.html.md
@@ -19,15 +19,6 @@ Read more about how to use the demonstration command on the
 
 This tool is available since version 2.0.0 of the AppSignal Ruby gem.
 
-## Table of Contents
-
-- [Usage](#usage)
-  - [With a specific environment](#with-a-specific-environment)
-  - [Standalone run](#standalone-run)
-- [Options](#options)
-  - [Environment option](#options)
-- [Exit codes](#exit-codes)
-
 ## Usage
 
 On the command line in your project run:

--- a/source/ruby/command-line/diagnose.html.md
+++ b/source/ruby/command-line/diagnose.html.md
@@ -6,19 +6,6 @@ The AppSignal Ruby gem ships with a self diagnostic tool. This tool can be used 
 
 This tool has been available since version `1.1.0` of the AppSignal Ruby gem.
 
-## Table of Contents
-
-- [The diagnostic report](#the-diagnostic-report)
-- [Submitting the report](#submitting-the-report)
-- [Usage](#usage)
-- [Options](#options)
-  - [Environment option](#environment-option)
-  - [Report submission option](#report-submission-option)
-- [Configuration output format](#configuration-output-format)
-  - [Configuration option values format](#configuration-option-values-format)
-  - [Configuration sources](#configuration-sources)
-- [Exit codes](#exit-codes)
-
 ## The diagnostic report
 
 This command line tool is useful when testing AppSignal on a system and validating the local configuration. It outputs useful information to debug issues and it checks if AppSignal agent is able to run on the machine's architecture and communicate with the AppSignal servers.

--- a/source/ruby/command-line/install.html.md
+++ b/source/ruby/command-line/install.html.md
@@ -5,14 +5,6 @@ description: "Command line tool to install AppSignal in a Ruby application. Docu
 
 Command line tool to install AppSignal in a Ruby application.
 
-## Table of Contents
-
-- [Description](#description)
-- [Configuration methods](#configuration-methods)
-- [Usage](#usage)
-- [Options](#options)
-- [Exit codes](#exit-codes)
-
 ## Description
 
 The command line tool is primarily used to help set up the configuration for AppSignal. Please follow the [installation guide](/application/new-application.html) when adding a new application to AppSignal.

--- a/source/ruby/configuration/index.html.md
+++ b/source/ruby/configuration/index.html.md
@@ -9,20 +9,6 @@ In this topic we'll explain how to configure AppSignal, what can be configured
 in the Ruby gem, what's the minimal configuration needed and how the
 configuration is loaded.
 
-## Table of Contents
-
-- [Minimal required configuration](#minimal-required-configuration)
-- [Configuration methods](#configuration-methods)
-  - [YAML configuration file](#yaml-configuration-file)
-  - [System environment variables](#system-environment-variables)
-- [Configuration options](/ruby/configuration/options.html)
-  - [Ignore actions](/ruby/configuration/ignore-actions.html)
-  - [Ignore errors](/ruby/configuration/ignore-errors.html)
-  - [Parameter filtering](/ruby/configuration/parameter-filtering.html)
-  - [Session data filtering](/ruby/configuration/session-data-filtering.html)
-- [Configuration load order](/ruby/configuration/load-order.html)
-- [Example configuration file](#example-configuration-file)
-
 ## Minimal required configuration
 
 ```yaml

--- a/source/ruby/configuration/parameter-filtering.html.md.erb
+++ b/source/ruby/configuration/parameter-filtering.html.md.erb
@@ -10,15 +10,6 @@ We support two methods of parameter filtering. If you use Rails, you can use [Ra
 
 !> **Warning**: Do not send personal data to AppSignal. If your parameters or session data contain personal data, please use filtering to avoid sending this data to AppSignal.
 
-## Table of Contents
-
-- [AppSignal parameter filtering](#appsignal-parameter-filtering)
-  - [Processor parameter filtering](#processor-parameter-filtering)
-- [Rails parameter filtering](#rails-parameter-filtering)
-  - [Filtering specific keys - Denylist](#filtering-specific-keys-denylist)
-  - [Allowing specific keys - Allowlist](#allowing-specific-keys-allowlist)
-- [Filter all parameters](#filter-all-parameters)
-
 ## AppSignal parameter filtering
 
 -> This feature is available since AppSignal Ruby gem [version 1.3.0](https://blog.appsignal.com/2016/08/29/gem-1-3.html).

--- a/source/ruby/configuration/session-data-filtering.html.md
+++ b/source/ruby/configuration/session-data-filtering.html.md
@@ -12,11 +12,6 @@ In Rails applications AppSignal automatically stores the contents of the user's 
 
 -> This feature is available since AppSignal Ruby gem [version 2.6.0](https://blog.appsignal.com/2018/05/08/ruby-gem-2-6.html).
 
-## Table of Contents
-
-- [AppSignal session data filtering](#appsignal-session-data-filtering)
-- [Skip sending session data](#skip-sending-session-data)
-
 ## AppSignal session data filtering
 
 Session data filtering will filter out any values from specified keys in the [`filter_session_data`](/ruby/configuration/options.html#option-filter_session_data) configuration option. Any filtered out value will be replaced with `[FILTERED]` before it leaves your application and is send to the AppSignal servers. This means that AppSignal never receives any of the filtered data.

--- a/source/ruby/index.html.md
+++ b/source/ruby/index.html.md
@@ -6,17 +6,6 @@ AppSignal supports the [Ruby language][ruby-lang] with a [Ruby gem][appsignal-ge
 
 It's also supported to add custom instrumentation to your application and get even more insights into the performance of your code.
 
-## Table of Contents
-
-- [Installation](/ruby/installation.html)
-- [Configuration](/ruby/configuration/index.html)
-- [Integrations](/ruby/integrations/index.html)
-- [Custom instrumentation](/ruby/instrumentation/index.html)
-- [Command line tools](/ruby/command-line/index.html)
-- [Ruby implementation support](#ruby-implementation-support)
-  - [Ruby MRI](#ruby-mri)
-  - [JRuby](#jruby)
-
 ## Configuration
 
 In the configuration topic we'll explain how to configure AppSignal, what can

--- a/source/ruby/installation.html.md
+++ b/source/ruby/installation.html.md
@@ -4,13 +4,6 @@ title: "Installing AppSignal for Ruby"
 
 Please follow the [installation guide](/application/new-application.html) when adding a new application to AppSignal.
 
-## Table of Contents
-
-- [Installation](#installation)
-  - [Requirements](#requirements)
-  - [Installing the gem](#installing-the-gem)
-- [Uninstall](#uninstall)
-
 ## Installation
 
 Please follow the [installation guide](/application/new-application.html) when adding a new application to AppSignal.

--- a/source/ruby/instrumentation/event-formatters.html.md
+++ b/source/ruby/instrumentation/event-formatters.html.md
@@ -10,12 +10,6 @@ The metadata for the events formatted by the event formatters will be visible on
 
 -> **Note**: If there are no other reasons to use [`ActiveSupport::Notifications`][as_instrumentation] instrumentation than AppSignal instrumentation, we recommend using the [`Appsignal.instrument` helper][instrument_helper] for instrumentation. Using `ActiveSupport::Notifications` adds more overhead than directly calling `AppSignal.instrument`. No event formatter will be needed either, as `AppSignal.instrument` accepts the metadata to be set directly.
 
-## Table of Contents
-
-- [Creating an event formatter](#creating-an-event-formatter)
-- [Example event formatter](#example-event-formatter)
-- [Changes in gem 2.5](#changes-in-gem-2-5)
-
 ## Creating an event formatter
 
 An AppSignal event formatter is a class with one instance method, `format`. This format method receives the event payload Hash and needs to return an Array with three values.

--- a/source/ruby/instrumentation/exception-handling.html.md
+++ b/source/ruby/instrumentation/exception-handling.html.md
@@ -16,22 +16,6 @@ To avoid these errors from being raised as problems in AppSignal it's possible
 to add exception handling to your code or even let AppSignal completely ignore
 certain errors.
 
-## Table of Contents
-
-- [Ignore errors](#ignore-errors)
-- [Exception handling](#exception-handling)
-  - [Rails rescue_from](#rails-rescue_from)
-  - [Handle 404s](#handle-404s)
-  - [Handle invalid authenticity tokens](#handle-invalid-authenticity-tokens)
-  - [Handle hacking attempts](#handle-hacking-attempts)
-- [Appsignal.set_error](#appsignal-set_error)
-  - [Tagging](#appsignal-set_error-tagging)
-  - [Namespaces](#appsignal-set_error-namespaces)
-- [Appsignal.send_error](#appsignal-send_error)
-  - [Tagging](#appsignal-send_error-tagging)
-  - [Namespaces](#appsignal-send_error-namespaces)
-- [Appsignal.listen_for_error](#appsignal-listen_for_error)
-
 ## Ignore errors
 
 The AppSignal configuration makes it possible to [ignore

--- a/source/ruby/instrumentation/index.html.md
+++ b/source/ruby/instrumentation/index.html.md
@@ -5,13 +5,3 @@ title: "Custom instrumentation for Ruby"
 AppSignal provides many ways to provide more insights in your application by
 adding more instrumentation or tagging the data that appears in the UI at
 AppSignal.com.
-
-## Table of Contents
-
-- [Integrating AppSignal](/ruby/instrumentation/integrating-appsignal.html)
-- [Add instrumentation](/ruby/instrumentation/instrumentation.html)
-- [Ignore instrumentation](/ruby/instrumentation/ignore-instrumentation.html)
-- [Exception handling](/ruby/instrumentation/exception-handling.html)
-- [Tagging](/ruby/instrumentation/tagging.html)
-- [Background jobs](/ruby/instrumentation/background-jobs.html)
-- [Method instrumentation](/ruby/instrumentation/method-instrumentation.html)

--- a/source/ruby/instrumentation/instrumentation.html.md
+++ b/source/ruby/instrumentation/instrumentation.html.md
@@ -33,13 +33,6 @@ instrumentation, as is used by Rails.
    your code. To track errors please read our
    [exception handling](/ruby/instrumentation/exception-handling.html) guide.
 
-## Table of Contents
-
-- [AppSignal instrumentation helpers](#appsignal-instrumentation-helpers) (Gem 1.3 and higher)
-  - [Nesting instrumentation](#nesting-instrumentation)
-  - [Collecting more data per event](#collecting-more-data-per-event)
-- [ActiveSupport::Notifications instrumentation](#activesupport-notifications)
-
 ## AppSignal instrumentation helpers
 
 -> This feature is available since AppSignal for Ruby gem 1.3. If you use an

--- a/source/ruby/instrumentation/minutely-probes.html.md
+++ b/source/ruby/instrumentation/minutely-probes.html.md
@@ -10,20 +10,6 @@ By default the AppSignal Ruby gem enables probes for [libraries](/ruby/integrati
 
 -> **Note**: We recommend using AppSignal Ruby gem `2.9.0` and up when using this feature.
 
-## Table of Contents
-
-- [Usage](#usage)
-  - [Multiple instances](#multiple-instances)
-- [Configuration](#configuration)
-- [Creating probes](#creating-probes)
-  - [Lambda probe](#lambda-probe)
-  - [Class probe](#class-probe)
-  - [Initialized class probe](#initialized-class-probe)
-- [Registering probes](#registering-probes)
-  - [Deprecated registration method](#deprecated-registration-method)
-- [Dependency requirements](#dependency-requirements)
-- [Overriding default probes](#overriding-default-probes)
-
 ## Usage
 
 The minutely probes allow the AppSignal Ruby gem to collect [custom metrics](/metrics/custom.html) by default for [integrations](/ruby/integrations) and app-specific metrics by [creating your own probe](#creating-probes).

--- a/source/ruby/instrumentation/request-queue-time.html.md
+++ b/source/ruby/instrumentation/request-queue-time.html.md
@@ -2,14 +2,6 @@
 title: "Track request queue time"
 ---
 
-## Table of Contents
-
-- [Queue times](#queue-times)
-- [Setup](#setup)
-  - [Nginx](#nginx)
-  - [Apache](#apache)
-- [Namespaces](#namespaces)
-
 ## Queue times
 
 A common setup for Ruby application is that the Ruby webserver such as Unicorn or Puma runs behind another (outer) webserver such as Nginx or Apache. Those are usually used to terminate SSL connections and handle static assets for example. When your Ruby webserver is busy processing requests, Nginx or Apache can still accept new connections and wait for a Ruby process to become available to handle the request. The outer webserver queue's the request in the meantime.

--- a/source/ruby/integrations/grape.html.md
+++ b/source/ruby/integrations/grape.html.md
@@ -9,13 +9,6 @@ For older versions of the AppSignal Ruby gem, check [grape-appsignal
 gem](https://github.com/aai/grape-appsignal) created by [Mark
 Madsen](https://github.com/idyll).
 
-## Table of Contents
-
-- [Installation](#installation)
-- [Grape on Rails](#grape-on-rails)
-- [Ignoring errors](#ignoring-errors)
-- [Example app](#example-app)
-
 ## Installation
 
 A Grape application requires a few manual steps to get working.

--- a/source/ruby/integrations/mongodb.html.md
+++ b/source/ruby/integrations/mongodb.html.md
@@ -2,12 +2,6 @@
 title: "MongoDB instrumentation"
 ---
 
-## Table of Contents
-
-- [Usage](#usage)
-- [Metrics](#metrics)
-- [Older Mongoid versions and MongoMapper](#Older-Mongoid-versions-and-MongoMapper)
-
 ## Usage
 
 The AppSignal gem version `1.0` and up supports the [Mongo Ruby Driver] gem and the [Mongoid] gem out-of-the-box.

--- a/source/ruby/integrations/puma.html.md
+++ b/source/ruby/integrations/puma.html.md
@@ -6,16 +6,6 @@ title: "Puma"
 
 Support for Puma was added in AppSignal Ruby gem version `1.0`.
 
-## Table of Contents
-
-- [Usage](#usage)
-- [Minutely probe](#minutely-probe)
-  - [Metrics](#minutely-probe-metrics)
-  - [Configuration](#minutely-probe-configuration)
-      - [Secrets](#minutely-probe-configuration-secrets)
-      - [Hostname](#minutely-probe-configuration-hostname)
-  - [Phased restart](#minutely-probe-phased-restart)
-
 ## Usage
 
 The AppSignal Ruby gem automatically inserts a listener into the Puma server. No further action is required.

--- a/source/ruby/integrations/rake.html.md
+++ b/source/ruby/integrations/rake.html.md
@@ -10,15 +10,6 @@ Every exception recorded in a Rake task will be sent to AppSignal and filed unde
 
 Depending on what version of the AppSignal gem you use and in what context some manual steps are required.
 
-## Table of Contents
-
-- [Integrations](#integrations)
-  - [Rails applications](#rails-applications)
-  - [Ruby applications](#ruby-applications)
-- [`Appsignal.stop` requirement](#appsignal-stop-requirement)
-- [Rake tasks and containers](#rake-tasks-and-containers)
-- [Examples](#examples)
-
 ## Integrations
 
 ### Rails applications

--- a/source/ruby/integrations/resque.html.md
+++ b/source/ruby/integrations/resque.html.md
@@ -7,12 +7,6 @@ title: "Resque"
 -> Support for Resque instrumentation was added in AppSignal for Ruby gem version `0.8`.  
 -> Support for automatic Resque instrumentation was added in AppSignal for Ruby gem version `2.11`.
 
-## Table of Contents
-
-- [Integration](#integration)
-- [Active Job support](#active-job-support)
-- [Example apps](#example-apps)
-
 ## Integration
 
 Since AppSignal Ruby gem 2.11 and newer Resque integration is automatic. If you have previously included or extended modules in your Resque job classes, they can now be removed.

--- a/source/ruby/integrations/sidekiq.html.md
+++ b/source/ruby/integrations/sidekiq.html.md
@@ -6,17 +6,6 @@ title: "Sidekiq"
 
 Support for Sidekiq was added in AppSignal Ruby gem version `0.8`.
 
-## Table of Contents
-
-- [Job naming](#job-naming)
-- [Usage](#usage)
-  - [Using with Rails](#usage-with-rails)
-  - [Using with Active Job](#usage-with-active-job)
-  - [Using standalone](#usage-standalone)
-- [Metrics](#metrics)
-- [Minutely probe](#minutely-probe)
-  - [Configuration](#minutely-probe-configuration)
-
 ## Job naming
 
 Job names are automatically detected based on the Sidekiq worker class name and are suffixed with the `perform` method name, resulting in something like: `MyWorker#perform`.

--- a/source/standalone-agent/installation.html.md
+++ b/source/standalone-agent/installation.html.md
@@ -4,14 +4,6 @@ title: "Standalone AppSignal Agent installation"
 
 In order to provide a full picture of your infrastructure, you should monitor not just application servers, but any server your application depends on (eg. database servers). In order to do this, we offer a standalone mode in our AppSignal agent. This allows you to run the AppSignal agent without having to start it from a Ruby/Elixir process.
 
-## Table of Contents
-
-- [Installation](#installation)
-  - [Ubuntu](#ubuntu)
-  - [Redhat Enterprise Linux/Centos](#redhat-enterprise-linux-centos)
-- [Configuration](#configuration)
-- [Collected metrics](#collected-metrics)
-
 ## Installation
 
 We are in the process of testing and packaging the standalone agent on Linux distributions that are most popular with our customers. [Let us know](mailto:support@appsignal.com) if you want to run the agent on a distribution that is not supported yet.

--- a/source/support/debugging.html.md
+++ b/source/support/debugging.html.md
@@ -9,22 +9,6 @@ Since it's good to share, here are a couple of our procedures.
 
 Also see our list of [known issues](/support/known-issues.html) for a list of problems that might affect your application.
 
-## Table of Contents
-
-- [Diagnose](#diagnose)
-  - [Diagnose information](#diagnose-information)
-- [Configuration](#configuration)
-- [No data appearing](#no-data-appearing)
-- [Logs](#logs)
-  - [Logs contents](#logs-contents)
-  - [Log message breakdown](#log-message-breakdown)
-  - [Log location](#log-location)
-  - [Log files on Heroku](#log-files-on-heroku)
-- [Is the agent running?](#is-the-agent-running)
-- [Other questions](#other-questions)
-- [Creating a reproducible state](#creating-a-reproducible-state)
-- [Contact us](#contact-us)
-
 ## Diagnose
 
 Our [Ruby gem](/ruby/index.html), [Elixir package](/elixir/index.html) and


### PR DESCRIPTION
In the docs there is already table of content available on right right sidebar so there is no need to have another table of content.