### PR TITLE
Rendering metric with and without tags in same graph

### DIFF
--- a/source/metrics/custom.html.md
+++ b/source/metrics/custom.html.md
@@ -203,7 +203,7 @@ Appsignal.set_gauge("my_metric_name", 200, %{tag_a: "b", tag_b: "c"})
 
 ## Rendering metric with and without tags
 
-If you created a custom metric and you have multiple tags associated with it, you can render this metric with and without the tag at the same time in a graph.
+If you created a custom metric and you have multiple tags associated with it, you can render the metric with and without the tag at the same time in a graph. The one without the tag will be a total of all the ones with the tag.
 
 ```ruby
 # Ruby

--- a/source/metrics/custom.html.md
+++ b/source/metrics/custom.html.md
@@ -200,3 +200,19 @@ Appsignal.set_gauge("my_metric_name", 100, %{tag_a: "a", tag_b: "b"})
 Appsignal.set_gauge("my_metric_name", 10, %{tag_a: "a", tag_b: "b"})
 Appsignal.set_gauge("my_metric_name", 200, %{tag_a: "b", tag_b: "c"})
 ```
+
+## Rendering metric with and without tags
+
+If you created a custom metric and you have multiple tags associated with it, you can render this metric with and without the tag at the same time in a graph.
+
+```ruby
+# Ruby
+Appsignal.increment_counter("sign_ups", 1, region: "eu")
+Appsignal.increment_counter("sign_ups", 1)
+```
+
+```elixir
+# Elixir
+Appsignal.increment_counter("sign_ups", 1, %{region: "eu"})
+Appsignal.increment_counter("sign_ups", 1)
+```


### PR DESCRIPTION
Updated the docs to include instructions on how to use the same graph to render a metric with and without tags.