### PR TITLE
Add the right key required for javascript package

### DIFF
--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -4,7 +4,7 @@ title: "Installing AppSignal for JavaScript"
 
 ## Installation
 
-First, add the `@appsignal/javascript` package to your `package.json`. Then, run `yarn install`/`npm install`. You'll also need a Push API key from the ["Push and deploy" section](https://appsignal.com/redirect-to/app?to=info) of your App settings page.
+First, add the `@appsignal/javascript` package to your `package.json`. Then, run `yarn install`/`npm install`. You'll also need a Front-end error monitoring key from the ["Push and deploy" section](https://appsignal.com/redirect-to/app?to=info) of your App settings page.
 
 You can also add these packages to your `package.json` on the command line:
 


### PR DESCRIPTION
On the front-end when `@appsignal/javascript` package is being used, the key which is required is Front-end error monitoring key and not the Push Key.