### PR TITLE
Add guides section with deploy markers guide

### DIFF
--- a/data/navigation.yml
+++ b/data/navigation.yml
@@ -19,6 +19,9 @@ sections:
             name: "Start"
             link: "/guides/"
           -
+            name: "Add a new application"
+            link: "/guides/new-application.html"
+          -
             name: "Reporting deploys"
             link: "/guides/deploy-markers.html"
       -
@@ -29,9 +32,6 @@ sections:
           -
             name: "Overview"
             link: "/application/"
-          -
-            name: "Add an application"
-            link: "/application/new-application.html"
           -
             name: "Anomaly detection"
             link: "/application/anomaly-detection/"

--- a/data/navigation.yml
+++ b/data/navigation.yml
@@ -11,6 +11,17 @@ sections:
         icon: "fas fa-question-circle"
         link: "/faq.html"
       -
+        name: "Guides"
+        icon: "fas fa-book-open"
+        link: "/guides/"
+        pages:
+          -
+            name: "Start"
+            link: "/guides/"
+          -
+            name: "Reporting deploys"
+            link: "/guides/deploy-markers.html"
+      -
         name: "Your applications"
         icon: "fas fa-server"
         link: "/application/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,10 +15,13 @@
   to = "/organization/team/owners.html"
 [[redirects]]
   from = "/getting-started/set-up-a-new-app.html"
-  to = "/application/new-application.html"
+  to = "/guides/new-application.html"
 [[redirects]]
   from = "/getting-started/new-application.html"
-  to = "/application/new-application.html"
+  to = "/guides/new-application.html"
+[[redirects]]
+  from = "/application/new-application.html"
+  to = "/guides/new-application.html"
 [[redirects]]
   from = "/getting-started/manage-app-settings.html"
   to = "/application/settings.html"

--- a/source/guides/deploy-markers.html.md
+++ b/source/guides/deploy-markers.html.md
@@ -92,7 +92,13 @@ Are deploys not being reported or incorrectly? [Contact us][contact] and we will
 
 ## Next steps
 
+- [Grouping parts of your app with namespaces](/guides/namespaces.html) - next guide
 - [Setting up backtrace links][error backtrace links]
+
+---
+
+- [Add a new application](/guides/new-application.html) - previous guide
+- [Getting started guides](/guides/) - Guides overview
 
 [deploy markers]: /application/markers/deploy-markers.html
 [heroku support]: /application/markers/deploy-markers.html#heroku-support

--- a/source/guides/deploy-markers.html.md
+++ b/source/guides/deploy-markers.html.md
@@ -1,0 +1,101 @@
+---
+title: "Reporting deploys to track improvements"
+---
+
+Every time an app gets deployed, changes that affect the app start running. By tracking deploys in AppSignal, error incidents and performance measurements are grouped per deploy. They will also allow for AppSignal.com to link directly from an [error backtrace]([error backtrace links]) to the line of code in your app for that version of the app.
+
+We will track deploys in AppSignal using deploy markers. Read more about [deploy markers], what they're used for, how to send them, and more.
+
+## Configuring AppSignal
+
+To report deploys to AppSignal we will use [deploy markers]. In this guide we will focus on the `revision` config option method of reporting deploy markers. (Other methods may be available, more details about why we prefer this method can be found on the [deploy markers] page.)
+
+The `revision` config option is configured differently per integration language. See the list of integrations below for the one your app uses.
+
+Heroku apps using the "Dyno Metadata" labs feature will [automatically report deploys][heroku support].
+
+### Automatically update the revision
+
+We recommend fetching the revision config option value from the SCM (Git/SVN/other) system dynamically on start or on deploy. This way the value doesn't have to be manually updated per deploy. If a Git SHA (or other SCM revision value) is used it will also be compatible with [error backtrace links].
+
+An example for Git:
+
+```bash
+git log --pretty=format:'%h' -n 1
+# Will output the current commit's short SHA
+```
+
+We will use the Git example in the integration examples below.
+
+### Ruby
+
+In the Ruby integration we will load the Git revision in the `config/appsignal.yml` config file. By using ERB we call the `git log` command and set the output as the `revision` config option.
+
+```ruby
+# config/appsignal.yml
+production:
+  revision: "<%= `git log --pretty=format:'%h' -n 1` %>"
+  # Other config
+```
+[Ruby `revision` configuration option details](/ruby/configuration/options.html#option-revision)
+
+### Elixir
+
+In the Elixir integration we will load the Git revision in the `config/appsignal.exs` config file (your file location may differ). In this `.exs` command we call the `git log` command with Elixir and set the output as the `revision` config option.
+
+```elixir
+# config/appsignal.exs
+{revision, _exitcode} = System.cmd("git", ["log", "--pretty=format:%h", "-n 1"])
+config :appsignal, :config,
+  revision: revision
+  # Other config
+```
+[Elixir `revision` configuration option details](/elixir/configuration/options.html#option-revision)
+
+### Node.js
+
+In the Node.js integration load the Git revision in the app's config file. In this `.js` command we call the `git log` command with Node.js and set the output as the `revision` config option.
+
+```javascript
+var childProcess = require("child_process");
+var REVISION = childProcess.execSync("git log --pretty=format:'%h' -n 1").toString();
+const appsignal = new Appsignal({
+  revision: REVISION
+  // Other config
+})
+```
+[Node.js `revision` configuration option details](/nodejs/configuration/options.html#option-revision)
+
+### JavaScript
+
+In the front-end JavaScript integration it's not possible to call the `git` executable, because the integration runs in the browser. Instead, set the "revision" value from the back-end app—such as a Rails or Phoenix app—into the HTML body as a property. Then load that property in the JavaScript config file.
+
+```html
+<body data-app-revision="REVISION VALUE">
+  <!-- Rest of the HTML -->
+```
+
+```javascript
+const body = document.querySelector("body");
+const appsignal = new Appsignal({
+  revision: body.dataset.appRevision
+  // Other config
+});
+```
+[JavaScript `revision` configuration option details](/front-end/configuration/options.html#option-revision)
+
+## Deploy
+
+After the app has been configured with the `revision` option, commit your changes and deploy the app. When the app starts AppSignal will create a deploy in the [deploys section] for your app.
+
+Are deploys not being reported or incorrectly? [Contact us][contact] and we will help you out!
+
+## Next steps
+
+- [Setting up backtrace links][error backtrace links]
+
+[deploy markers]: /application/markers/deploy-markers.html
+[heroku support]: /application/markers/deploy-markers.html#heroku-support
+[error backtrace links]: /application/backtrace-links.html
+[deploys section]: https://appsignal.com/redirect-to/app?to=markers
+[contact]: mailto:support@appsignal.com

--- a/source/guides/index.html.md
+++ b/source/guides/index.html.md
@@ -6,4 +6,5 @@ You have set up AppSignal and data is coming in from your app. What's next?
 
 In the next couple steps we'll guide you through ways to make the data being reported from your app more useful. Follow the guides below in a step-by-step process, or jump ahead to the guide that seems interesting for your app.
 
+1. [Add a new application](/guides/new-application.html)
 1. [Reporting deploys to track improvements](/guides/deploy-markers.html)

--- a/source/guides/index.html.md
+++ b/source/guides/index.html.md
@@ -1,0 +1,9 @@
+---
+title: "Getting started guides"
+---
+
+You have set up AppSignal and data is coming in from your app. What's next?
+
+In the next couple steps we'll guide you through ways to make the data being reported from your app more useful. Follow the guides below in a step-by-step process, or jump ahead to the guide that seems interesting for your app.
+
+1. [Reporting deploys to track improvements](/guides/deploy-markers.html)

--- a/source/guides/new-application.html.md
+++ b/source/guides/new-application.html.md
@@ -2,7 +2,7 @@
 title: "Add a new application"
 ---
 
-To get your app running on AppSignal you start by clicking the "add app" link on the application overview page, or use this link to the ["add app" wizard for your organization](https://appsignal.com/redirect-to/organization?to=sites/new).
+To get a new app running on AppSignal, start by clicking the "add app" link on the application overview page, or use this link to the ["add app" wizard for your organization](https://appsignal.com/redirect-to/organization?to=sites/new).
 
 ![Add app](/assets/images/screenshots/dashboard.png)
 
@@ -10,7 +10,7 @@ In the wizard you will first be asked for what language you want to install AppS
 
 After choosing a language you will be presented with instructions on how to install AppSignal in your app.
 
-Once you deploy AppSignal will start receiving data and you're good to go!
+Once the app is deployed AppSignal will start receiving data and you're good to go!
 
 ## Installation instructions
 
@@ -23,3 +23,11 @@ Some language integrations and support for libraries require some manual steps t
 AppSignal will detect and register new Ruby, Elixir & Node.js applications when it receives data from the application and not before it. Using their installers this should be done automatically. When installing AppSignal manually, please use the demo command line tool ([Ruby](/ruby/command-line/demo.html) / [Elixir](/elixir/command-line/demo.html)) or start your application and perform some requests/jobs to send data to AppSignal.com.
 
 JavaScript applications will create an app beforehand that generate an application-specific Push API key to be used for that application.
+
+## Next steps
+
+- [Reporting deploys to track improvements](/guides/deploy-markers.html) - next guide
+
+---
+
+- [Getting started guides](/guides/) - Guides overview

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -9,8 +9,7 @@ In this documentation we aim to give you all the information you need to get sta
 
 ## Getting started
 
-- [Add a new application](/application/new-application.html)
-- [Getting started guides](/guides/)
+- [Getting started guides](/guides/) - Start here if you're new to AppSignal!
 - [AppSignal for Ruby](/ruby/index.html)
 - [AppSignal for Elixir](/elixir/index.html)
 - [AppSignal for Node.js](https://docs.appsignal.com/nodejs/)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -10,6 +10,7 @@ In this documentation we aim to give you all the information you need to get sta
 ## Getting started
 
 - [Add a new application](/application/new-application.html)
+- [Getting started guides](/guides/)
 - [AppSignal for Ruby](/ruby/index.html)
 - [AppSignal for Elixir](/elixir/index.html)
 - [AppSignal for Node.js](https://docs.appsignal.com/nodejs/)


### PR DESCRIPTION
Add first guide about deploy markers to the new guides section in the
docs. This section will be more hands on in taking people through the
steps we recommend they take to get the most out of AppSignal.

I started with the deploy markers guide because that would be my first
recommendation after an app reports data to AppSignal.

There's a list of links to other guides that have yet to be written.