### PR TITLE
Update the ignore_actions example to include the app name as well

### DIFF
--- a/source/elixir/configuration/ignore-actions.html.md.erb
+++ b/source/elixir/configuration/ignore-actions.html.md.erb
@@ -16,11 +16,11 @@ use Mix.Config
 config :appsignal, :config,
   name: "appsignal_phoenix_example",
   push_api_key: "00000000-0000-0000-0000-000000000000",
-  ignore_actions: ["PingController#is_up", "SecondController#healthcheck"]
+  ignore_actions: ["AppsignalPhoenixExampleWeb.PingController#is_up", "AppsignalPhoenixExampleWeb.SecondController#healthcheck"]
 ```
 
 You can also configure ignore actions via an environment variable.
 
 ```bash
-export APPSIGNAL_IGNORE_ACTIONS="PingController#is_up,SecondController#healthcheck"
+export APPSIGNAL_IGNORE_ACTIONS="AppsignalPhoenixExampleWeb.PingController#is_up,AppsignalPhoenixExampleWeb.SecondController#healthcheck"
 ```


### PR DESCRIPTION
The `ignore_actions` in Elixir need to include the app name as well, otherwise AppSignal will still report the statistics rather than ignoring it.