### PR TITLE
Move add new application page to guides

### DIFF
--- a/data/navigation.yml
+++ b/data/navigation.yml
@@ -19,6 +19,9 @@ sections:
             name: "Start"
             link: "/guides/"
           -
+            name: "Add a new application"
+            link: "/guides/new-application.html"
+          -
             name: "Reporting deploys"
             link: "/guides/deploy-markers.html"
       -
@@ -29,9 +32,6 @@ sections:
           -
             name: "Overview"
             link: "/application/"
-          -
-            name: "Add an application"
-            link: "/application/new-application.html"
           -
             name: "Anomaly detection"
             link: "/application/anomaly-detection/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,10 +15,13 @@
   to = "/organization/team/owners.html"
 [[redirects]]
   from = "/getting-started/set-up-a-new-app.html"
-  to = "/application/new-application.html"
+  to = "/guides/new-application.html"
 [[redirects]]
   from = "/getting-started/new-application.html"
-  to = "/application/new-application.html"
+  to = "/guides/new-application.html"
+[[redirects]]
+  from = "/application/new-application.html"
+  to = "/guides/new-application.html"
 [[redirects]]
   from = "/getting-started/manage-app-settings.html"
   to = "/application/settings.html"

--- a/source/guides/deploy-markers.html.md
+++ b/source/guides/deploy-markers.html.md
@@ -92,7 +92,13 @@ Are deploys not being reported or incorrectly? [Contact us][contact] and we will
 
 ## Next steps
 
+- [Grouping parts of your app with namespaces](/guides/namespaces.html) - next guide
 - [Setting up backtrace links][error backtrace links]
+
+---
+
+- [Add a new application](/guides/new-application.html) - previous guide
+- [Getting started guides](/guides/) - Guides overview
 
 [deploy markers]: /application/markers/deploy-markers.html
 [heroku support]: /application/markers/deploy-markers.html#heroku-support

--- a/source/guides/index.html.md
+++ b/source/guides/index.html.md
@@ -6,4 +6,5 @@ You have set up AppSignal and data is coming in from your app. What's next?
 
 In the next couple steps we'll guide you through ways to make the data being reported from your app more useful. Follow the guides below in a step-by-step process, or jump ahead to the guide that seems interesting for your app.
 
+1. [Add a new application](/guides/new-application.html)
 1. [Reporting deploys to track improvements](/guides/deploy-markers.html)

--- a/source/guides/new-application.html.md
+++ b/source/guides/new-application.html.md
@@ -2,7 +2,7 @@
 title: "Add a new application"
 ---
 
-To get your app running on AppSignal you start by clicking the "add app" link on the application overview page, or use this link to the ["add app" wizard for your organization](https://appsignal.com/redirect-to/organization?to=sites/new).
+To get a new app running on AppSignal, start by clicking the "add app" link on the application overview page, or use this link to the ["add app" wizard for your organization](https://appsignal.com/redirect-to/organization?to=sites/new).
 
 ![Add app](/assets/images/screenshots/dashboard.png)
 
@@ -10,7 +10,7 @@ In the wizard you will first be asked for what language you want to install AppS
 
 After choosing a language you will be presented with instructions on how to install AppSignal in your app.
 
-Once you deploy AppSignal will start receiving data and you're good to go!
+Once the app is deployed AppSignal will start receiving data and you're good to go!
 
 ## Installation instructions
 
@@ -23,3 +23,11 @@ Some language integrations and support for libraries require some manual steps t
 AppSignal will detect and register new Ruby, Elixir & Node.js applications when it receives data from the application and not before it. Using their installers this should be done automatically. When installing AppSignal manually, please use the demo command line tool ([Ruby](/ruby/command-line/demo.html) / [Elixir](/elixir/command-line/demo.html)) or start your application and perform some requests/jobs to send data to AppSignal.com.
 
 JavaScript applications will create an app beforehand that generate an application-specific Push API key to be used for that application.
+
+## Next steps
+
+- [Reporting deploys to track improvements](/guides/deploy-markers.html) - next guide
+
+---
+
+- [Getting started guides](/guides/) - Guides overview

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -9,8 +9,7 @@ In this documentation we aim to give you all the information you need to get sta
 
 ## Getting started
 
-- [Add a new application](/application/new-application.html)
-- [Getting started guides](/guides/)
+- [Getting started guides](/guides/) - Start here if you're new to AppSignal!
 - [AppSignal for Ruby](/ruby/index.html)
 - [AppSignal for Elixir](/elixir/index.html)
 - [AppSignal for Node.js](https://docs.appsignal.com/nodejs/)


### PR DESCRIPTION
This page is already a guide but part of the application section. Move
it to the guides section so that all the guides are in one place.

Update the netlify redirect links so that the old and really old URLs
point to the new guide location.