### PR TITLE
Add ignore namespaces guide

### DIFF
--- a/data/navigation.yml
+++ b/data/navigation.yml
@@ -49,6 +49,9 @@ sections:
               -
                 name: "Ignore actions"
                 link: "/guides/filter-data/ignore-actions.html"
+              -
+                name: "Ignore namespaces"
+                link: "/guides/filter-data/ignore-namespaces.html"
       -
         name: "Your applications"
         icon: "fas fa-server"

--- a/source/application/namespaces.html.md
+++ b/source/application/namespaces.html.md
@@ -4,7 +4,7 @@ title: "Namespaces"
 
 Namespaces are a way to group error incidents, performance incidents and metrics from [actions](/appsignal/terminology.html#actions). [By default](#default-namespaces) AppSignal provides three namespaces: the "web", "background" and "frontend" namespaces. You can add your own namespaces to separate parts of your app like the API or Admin panel with [custom namespaces](#custom-namespaces).
 
--> 📖 Also read our guide on [how to set up namespaces](/guides/namespaces.html).
+-> 📖 Read our guide on [how to set up namespaces](/guides/namespaces.html).
 
 ## What can you do with namespaces?
 
@@ -63,12 +63,10 @@ documentation for our [Ruby](/ruby/instrumentation/namespaces.html) and
 
 ## Ignoring namespaces
 
--> The `ignore_namespaces` feature was introduced in AppSignal for Ruby gem version 2.3.0, AppSignal for Elixir package version 1.3.0 and AppSignal for Node.js package version 1.0.0.
-
 Sometimes you have a certain part of an application that does not need to be monitored by AppSignal. The most common use case is an administration panel that you use internally which doesn't need constant monitoring. By ignoring an entire namespace AppSignal will ignore all transactional data from all actions in the configured namespaces.
 
-To ignore a namespace first make sure to configure AppSignal to report all actions you want to ignore under a certain namespace, as described in the [Custom namespaces](#custom-namespaces) section.
+To ignore a namespace first make sure to configure AppSignal to report all actions you want to ignore under a certain namespace, as described in the [namespaces guide](/guides/namespace.html) section.
 
-Then configure AppSignal in your app to ignore the namespace, see the documentation for [Ruby](/ruby/instrumentation/namespaces.html#ignore-by-namespace) & [Elixir](/elixir/instrumentation/namespaces.html#ignore-by-namespace) apps.
+Then configure AppSignal in your app to ignore the namespace, see our [ignore namespaces guide](/guides/filter-data/ignore-namespaces.html) for this.
 
 After restarting your app the actions in the selected namespace should no longer be reported on AppSignal.com.

--- a/source/guides/filter-data/ignore-actions.html.md
+++ b/source/guides/filter-data/ignore-actions.html.md
@@ -8,7 +8,7 @@ In an app there may be certain actions that you don't want to report to AppSigna
 
 ## Ignoring actions
 
-These actions can be ignored by customizing the configuration for AppSignal integrations in apps. The "ignore actions" configuration option will allow you to configure a list of action names, as reported to AppSignal. Any action in this list will be ignored, meaning the data of these actions will not be sent to the AppSignal servers, and will not count towards your [organization's billing plan](https://appsignal.com/plans).
+These actions can be ignored by customizing the configuration for AppSignal integrations in apps. The "ignore actions" configuration option will allow you to configure a list of action names, as reported to AppSignal. Any action in this list will be ignored, meaning the data from these actions will not be sent to the AppSignal servers, and will not count towards your [organization's billing plan](https://appsignal.com/plans).
 
 The "ignore actions" config option is configured differently per integration language. See the list of integrations below for the one your app uses.
 
@@ -72,6 +72,10 @@ const appsignal = new Appsignal({
 [nodejs ignore_actions]: /nodejs/configuration/options.html#option-ignoreActions
 
 ## Next steps
+
+- [Ignore namespaces](/guides/filter-data/ignore-namespaces.html) - the next step in this guide
+
+---
 
 - [Ignore errors](/guides/filter-data/ignore-errors.html) - the previous step in this guide
 - [Filtering app data](/guides/filter-data/) - the start of this guide

--- a/source/guides/filter-data/ignore-namespaces.html.md
+++ b/source/guides/filter-data/ignore-namespaces.html.md
@@ -1,0 +1,90 @@
+---
+title: "Ignore namespaces"
+---
+
+In a previous guide we've discussed [setting up custom namespaces](/guides/namespaces.html) in an app. These namespaces can be used to group parts of an app together, but it can also be used to ignore these namespaces entirely. This may be easier than to [ignore a lot of individual actions](/guides/filter-data/ignore-actions.html).
+
+-> 💡 Ignoring namespaces will **ignore error and performance data** from all actions in namespaces. [Custom metrics data](/metrics/custom.html) recorded in any of the namespace actions will still be reported.
+
+## Ignoring namespaces
+
+Namespaces can be ignored by customizing the configuration for AppSignal integrations in apps. The "ignore namespaces" configuration option will allow you to configure a list of namespaces, as reported to AppSignal. Any namespaces in this list will be ignored, meaning the data from these actions will not be sent to the AppSignal servers, and will not count towards your [organization's billing plan](https://appsignal.com/plans).
+
+The "ignore namespaces" config option is configured differently per integration language. See the list of integrations below for the one your app uses.
+
+-> 💡 If you're unsure of the namespaces to configure in the app configuration, find the namespace name to ignore in your app on AppSignal.com in the namespaces filtering drop down, and copy it into the AppSignal configuration.
+
+## Ruby
+
+To ignore namespaces in Ruby, add the following to your AppSignal configuration file. The [`ignore_namespaces`][ruby ignore_namespaces] value is an Array of Strings.
+
+```yaml
+# Example: config/appsignal.yml
+production:
+  ignore_namespaces:
+  - "http_request" # "web" namespace on AppSignal
+  - "background_job" # "background" namespace on AppSignal
+  - "admin"
+  - "private"
+  # Other config
+```
+
+For more information about this config option, see the [`ignore_namespaces` config option][ruby ignore_namespaces] documentation.
+
+[ruby ignore_namespaces]: /ruby/configuration/options.html#option-ignore_namespaces
+
+## Elixir
+
+To ignore namespaces in Elixir, add the following to your AppSignal configuration file. The [`ignore_namespaces`][elixir ignore_namespaces] value is a List of Strings.
+
+```elixir
+# Example: config/appsignal.exs
+use Mix.Config
+
+config :appsignal, :config,
+  ignore_namespaces: [
+    "http_request", # "web" namespace on AppSignal
+    "background_job", # "background" namespace on AppSignal
+    "admin",
+    "private"
+  ]
+```
+
+For more information about this config option, see the [`ignore_namespaces` config option][elixir ignore_namespaces] documentation.
+
+[elixir ignore_namespaces]: /elixir/configuration/options.html#option-ignore_namespaces
+
+## Node.js
+
+To ignore namespaces in Node.js, add the following to your AppSignal configuration file. The [`ignoreNamespaces`][nodejs ignore_namespaces] value is an Array of Strings.
+
+```js
+// Example: appsignal.js
+const { Appsignal } = require("@appsignal/nodejs");
+
+const appsignal = new Appsignal({
+  // Other config
+  ignoreNamespaces: [
+    "web",
+    "background",
+    "admin",
+    "private"
+  ]
+});
+```
+
+For more information about this config option, see the [`ignoreNamespaces` config option][nodejs ignore_namespaces] documentation.
+
+[nodejs ignore_namespaces]: /nodejs/configuration/options.html#option-ignoreNamespaces
+
+## Next steps
+
+- [Ignore namespaces](/guides/filter-data/ignore-namespaces.html) - the next step in this guide
+
+---
+
+- [Ignore errors](/guides/filter-data/ignore-errors.html) - the previous step in this guide
+- [Filtering app data](/guides/filter-data/) - the start of this guide
+- [Getting started guides](/guides/) - Guides overview
+
+[notifications]: /application/notification-settings.html

--- a/source/guides/namespaces.html.md
+++ b/source/guides/namespaces.html.md
@@ -175,6 +175,6 @@ Are namespaces not being reported or incorrectly? [Contact us][contact] and we w
 - [Getting started guides](/guides/) - Guides overview
 
 [namespaces]: /application/namespaces.html
-[ignoring namespaces]: /application/namespaces.html#ignoring-namespaces
+[ignoring namespaces]: /guides/filter-data/ignore-namespaces.html
 [filtering]: /guides/filter-data/
 [contact]: mailto:support@appsignal.com


### PR DESCRIPTION
We already had a namespaces guide, but it didn't go into how to ignore
a namespaces. This guide, in the filter data topic, does explain it and
is linked to from the namespaces guide. It's not part of that guide,
because setting up namespaces and ignoring them are two different use
cases.