### PR TITLE
Update Node.js default environment value

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -110,7 +110,8 @@ options:
     nodejs:
       config_key: environment
       type: string
-      default: env
+      default_value: |
+        Read from environment variable `NODE_ENV`, defaults to "development".
       description: |
         The environment of the app to be reported to AppSignal.
   - config_key: name


### PR DESCRIPTION
From the Node.js integration I saw it defaults to the NODE_ENV
environment variable and has a fallback on "development".

https://github.com/appsignal/appsignal-nodejs/blob/a9b2f47aa56150a37d0b28175835262296c03d61/packages/nodejs/src/config.ts#L27