### PR TITLE
Fix markdown helper error on first build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-bundle exec middleman build --no-parallel
+bundle exec middleman build

--- a/config.rb
+++ b/config.rb
@@ -125,6 +125,9 @@ helpers do
   end
 
   def markdown(content)
+    # Set the markdown renderer scope to current view object, so that it can
+    # call view helpers, instead of erroring on a `nil` scope object.
+    AppsignalMarkdown.scope = self if AppsignalMarkdown.scope.nil?
     # https://github.com/hashicorp/middleman-hashicorp/blob/14c705614b2f97b5a78903f17b904f767c1fdbe2/lib/middleman-hashicorp/redcarpet.rb
     Redcarpet::Markdown.new(AppsignalMarkdown, AppsignalMarkdown::OPTIONS).render(content)
   end


### PR DESCRIPTION
When a page is loaded that uses the markdown helper, in a view that's
nor markdown, middleman would raise an error. This would occur in an
`.erb` for the integration options pages if it was the first page to be
requested after middleman server started.

This could also be a fix for #269, where pages were built in parallel
and caused a similar error. There too it could be that one of the build
processes rendered such as page first, causing the error.

Fix it by setting the `scope` class attribute on the AppsignalMarkdown
class if it's not present to the current view object.
This way the AppsignalMarkdown class can call view helpers, instead of
erroring on a `nil` scope object.

[skip review]