### PR TITLE
Add clearer docs about what both JS integrations support

### DIFF
--- a/source/front-end/index.html.md
+++ b/source/front-end/index.html.md
@@ -6,12 +6,18 @@ AppSignal has amazing support for catching errors from front-end JavaScript appl
 
 !> **NOTE:** Uncaught exceptions are **not** captured by default. [Read this section to find out why](/front-end/error-handling.html#uncaught-exceptions). You can enable this functionality by enabling the [`plugin-window-events`](/front-end/plugins/plugin-window-events.html) plugin.
 
-## Creating a Push API Key
+## Supported browsers
 
-Before you begin, you'll need to locate your Push API key. Finding this is easy - look for the ["Push and deploy" section](https://appsignal.com/redirect-to/app?to=info) of your App settings page. You'll be able to find your API key under the "Front-end error monitoring". Once you have your key, follow the instructions under the [Installation](/front-end/installation.html) section to use it in your application.
+This package can be used in any ECMAScript 5 compatible browser. We aim for compatibility down to Internet Explorer 9 [(roughly 0.22% of all browsers used today)](https://www.w3counter.com/globalstats.php). All browsers older than this can only supported on a “best effort” basis, and full functionality cannot be guaranteed.
 
-## About the Retry Queue
+When developing, don’t forget to check browser support on [Can I Use?](https://caniuse.com/) and the [ES6 Compatibility Table](https://kangax.github.io/compat-table/es6/), and provide the appropriate polyfills or fallbacks. **In a small percentage of browsers, a `Promise` polyfill may be required to use this library.**
 
-If, for any reason, pushing an error to the API fails (e.g. if the network connection is not working), the `Span` object that it belongs to is placed in the retry queue. By default, requests are retried **5 times** with exponential backoff. If the request succeeds, the corresponding `Span` is removed from the queue. Once the retry limit has been reached, any `Span`s left in the queue are discarded.
+## Other supported environments
 
-!> No caching is currently implemented for the retry queue, meaning that if a `Span` is in the queue when the user navigates away from your aplication, that `Span` will also be discarded.
+`@appsignal/javascript` is more than just a front-end library! It's also designed to work in a variety of other JavaScript runtimes and use-cases where the `@appsignal/nodejs` library may not be a viable choice. `@appsignal/javascript` supports:
+
+- ✅ **Electron apps**
+- ✅ **Short-lived processes**
+- ✅ **Serverless functions**
+- ✅ **Statically generated apps**
+- ✅ **React Native/Expo apps**

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -4,6 +4,10 @@ title: "Installing AppSignal for JavaScript"
 
 Please follow the [installation guide](/guides/new-application.html) first, when adding a new application to AppSignal.
 
+## Creating a Push API Key
+
+Before you begin, you'll need to locate your Push API key. Finding this is easy - look for the ["Push and deploy" section](https://appsignal.com/redirect-to/app?to=info) of your App settings page. You'll be able to find your API key under the "Front-end error monitoring". Once you have your key, follow the instructions under the [Installation](/front-end/installation.html) section to use it in your application.
+
 ## Installation
 
 First, add the `@appsignal/javascript` package to your `package.json`. Then, run `yarn install`/`npm install`. You'll also need a Front-end error monitoring key from the ["Push and deploy" section](https://appsignal.com/redirect-to/app?to=info) of your App settings page.
@@ -18,35 +22,27 @@ npm install --save @appsignal/javascript
 You can then import and use the package in your bundle:
 
 ```javascript
-import Appsignal from "@appsignal/javascript" // For ES Module
-const Appsignal = require("@appsignal/javascript").default // For CommonJS module
+import Appsignal from "@appsignal/javascript"; // For ES Module
+const Appsignal = require("@appsignal/javascript").default; // For CommonJS module
 
 const appsignal = new Appsignal({
-  key: "YOUR FRONTEND API KEY"
-})
+  key: "YOUR FRONTEND API KEY",
+});
 ```
 
 It’s recommended (although not necessarily required) to use the instance of the `Appsignal` object like a singleton. One way that you can do this is by `export`ing an instance of the library from a `.js`/`.ts` file somewhere in your project.
 
 ```javascript
-import Appsignal from "@appsignal/javascript"
+import Appsignal from "@appsignal/javascript";
 
 export default new Appsignal({
-  key: "YOUR FRONTEND API KEY"
-})
+  key: "YOUR FRONTEND API KEY",
+});
 ```
 
 Currently, we have no plans to supply a CDN-hosted version of this library.
 
 !> **NOTE:** If you are running a CDN in front of your assets, you'll need to make [two changes](/front-end/troubleshooting.html) for error reporting to be able to send errors to our API endpoint. Read more about the [required changes](/front-end/troubleshooting.html). <br /><br />If you use Content Security Policy, make sure to add the correct headers as [described here](/front-end/troubleshooting.html#content-security-policy-csp).
-
-### Supported browsers
-
-This package can be used in any ECMAScript 5 compatible browser. We aim for compatibility down to Internet Explorer 9 [(roughly 0.22% of all browsers used today)](https://www.w3counter.com/globalstats.php). All browsers older than this can only supported on a “best effort” basis, and full functionality cannot be guaranteed.
-
-When developing, don’t forget to check browser support on [Can I Use?](https://caniuse.com/) and the [ES6 Compatibility Table](https://kangax.github.io/compat-table/es6/), and provide the appropriate polyfills or fallbacks. **In a small percentage of browsers, a `Promise` polyfill may be required to use this library.**
-
-`@appsignal/javascript` also works in React Native/Expo apps!
 
 ---
 

--- a/source/front-end/installation.html.md
+++ b/source/front-end/installation.html.md
@@ -6,7 +6,7 @@ Please follow the [installation guide](/guides/new-application.html) first, when
 
 ## Creating a Push API Key
 
-Before you begin, you'll need to locate your Push API key. Finding this is easy - look for the ["Push and deploy" section](https://appsignal.com/redirect-to/app?to=info) of your App settings page. You'll be able to find your API key under the "Front-end error monitoring". Once you have your key, follow the instructions under the [Installation](/front-end/installation.html) section to use it in your application.
+Before you begin, you'll need to find your Push API key on the ["Push and deploy" section](https://appsignal.com/redirect-to/app?to=info) of your App settings page. You'll be able to find your API key under the "Front-end error monitoring". Once you have your key, follow the instructions under the [Installation](/front-end/installation.html) section to use it in your application.
 
 ## Installation
 

--- a/source/front-end/span.html.md
+++ b/source/front-end/span.html.md
@@ -9,7 +9,7 @@ A `Span` is the name of the object that we use to capture data about an error an
 A `Span` can be created by calling `appsignal.createSpan()`, which initializes a new `Span` object with any default options that you passed when the `Appsignal` object was initialized.
 
 ```js
-const span = appsignal.createSpan()
+const span = appsignal.createSpan();
 ```
 
 The `createSpan()` method can also take a function as a parameter, allowing you to define the `Span`'s data as the same time as it is created.
@@ -17,21 +17,18 @@ The `createSpan()` method can also take a function as a parameter, allowing you 
 ```js
 const span = appsignal.createSpan((span) => {
   return span.setTags({
-    tag: "value"
-  })
-})
+    tag: "value",
+  });
+});
 ```
 
 `Span`s cannot be nested, nor can multiple `Span`s be passed to `appsignal.send()` at once. We recommend using `Promise.all` for concurrent `send` operations.
 
 ```js
-const span1 = appsignal.createSpan()
-const span2 = appsignal.createSpan()
+const span1 = appsignal.createSpan();
+const span2 = appsignal.createSpan();
 
-Promise.all([
-  appsignal.send(span1),
-  appsignal.send(span2)
-])
+Promise.all([appsignal.send(span1), appsignal.send(span2)]);
 ```
 
 ## Updating a `Span`
@@ -39,23 +36,21 @@ Promise.all([
 After a `Span` is created, you can begin adding data to it using methods on the `Span` object:
 
 ```js
-const span = appsignal.createSpan()
-span.setTags({ tag: "value" })
+const span = appsignal.createSpan();
+span.setTags({ tag: "value" });
 
-console.log(span.serialize().tags) // { tag: "value" }
+console.log(span.serialize().tags); // { tag: "value" }
 ```
 
 Each method that modifies the `Span` returns `this`, allowing you to chain methods together:
 
 ```js
-const span = appsignal.createSpan()
+const span = appsignal.createSpan();
 
-span
-  .setTags({ tag: "value" })
-  .setError(new Error("test error"))
+span.setTags({ tag: "value" }).setError(new Error("test error"));
 
-console.log(span.serialize().tags)    // { tag: "value" }
-console.log(span.serialize().error)   // { name: "Error", message: "test error", backtrace: [...] }
+console.log(span.serialize().tags); // { tag: "value" }
+console.log(span.serialize().error); // { name: "Error", message: "test error", backtrace: [...] }
 ```
 
 ### `span.setAction(name: string)`
@@ -90,10 +85,10 @@ When you're finished adding data to the `Span`, it can then be passed to `appsig
 
 ```js
 const span = appsignal.createSpan((span) => {
-  return span.setError(new Error("test error"))
-})
+  return span.setError(new Error("test error"));
+});
 
-appsignal.send(span)
+appsignal.send(span);
 ```
 
 The `send()` method is different to the `sendError()` method as it allows a `Span` to be passed as a parameter, which is either pushed immediately to the API, or in the case of a network error, added to the queue to be retried later.
@@ -103,3 +98,9 @@ Once the `Span` is passed to `appsignal.send()`, any [Hooks](/front-end/hooks.ht
 - Decorators
 - Optional `tags` or `namespace` arguments to `appsignal.send()`
 - Overrides
+
+### About the Retry Queue
+
+If, for any reason, pushing an error to the API fails (e.g. if the network connection is not working), the `Span` object that it belongs to is placed in the retry queue. By default, requests are retried **5 times** with exponential backoff. If the request succeeds, the corresponding `Span` is removed from the queue. Once the retry limit has been reached, any `Span`s left in the queue are discarded.
+
+!> No caching is currently implemented for the retry queue, meaning that if a `Span` is in the queue when the user navigates away from your aplication, that `Span` will also be discarded.

--- a/source/nodejs/index.html.md
+++ b/source/nodejs/index.html.md
@@ -2,15 +2,24 @@
 title: "AppSignal for Node.js"
 ---
 
-AppSignal now supports [Node.js](https://nodejs.org/)! 
+AppSignal now supports [Node.js](https://nodejs.org/)!
 
 We're proud to bring the same great performance monitoring and error tracking that we offer Ruby and Elixir customers to the Node.js ecosystem. The package supports pure JavaScript applications and TypeScript applications and can auto-instrument various frameworks and packages with optional plugins. Other frameworks and packages might require some custom instrumentation.
 
 The new Node.js implementation contains some concepts that vary from the Ruby and Elixir implementations. Be sure to check out the [Tracing section][tracing] to familiarize yourself with any differences.
 
-## Supported versions
+## Supported environments
 
 Our Node.js support tracks the active LTS release and above, which is currently [v10](https://github.com/nodejs/Release) and above.
+
+Node.js is an incredibly flexible runtime, which allows it to be used for a multiple of different use-cases. AppSignal was primarily designed for use on a server, so there are a few places that the Node.js integration is currently not suitable:
+
+- ❌ **Electron apps:** We don't recommend using `@appsignal/nodejs` inside [Electron](https://www.electronjs.org/) applications. As we designed the [agent](/appsignal/terminology.html#agent) to run on a server, it is not currently useful in this environment. It will also lead to possibly [unwanted complexity around cross-compilation](https://www.electronjs.org/docs/tutorial/using-native-node-modules) of the native extension.
+- ❌ **Short-lived processes:** Short-lived processes, such as CLI tools, are a poor fit for the agent, which must be able to stay running for a period of time (at least 60 seconds).
+- ❌ **Serverless functions:** Serverless functions are meant to be short-lived processes, so they are also a poor fit for the agent.
+- ❌ **Statically generated apps:** Some environments (e.g [Gatsby.js](https://www.gatsbyjs.com/), [Next.js on Vercel](https://vercel.com/docs/next.js/overview), [Svelte](https://svelte.dev/) offer some access to Node.js APIs but ultimately compile thier code down to a client side application, and therefore aren't suitable for the Node.js library.
+
+But don't worry! The [`@appsignal/javascript` library](/front-end/) does not require the agent and will work in the places that `@appsignal/nodejs` doesn't currently work, but only error tracking is supported at the moment.
 
 [installation]: /nodejs/installation.html
 [configuration]: /nodejs/configuration


### PR DESCRIPTION
Following a round of testing, this PR adds some clearer documentation to suggest where our customers should prefer the Node.js integration, and where they should prefer the JavaScript integration.

I feel like this could be even clearer, so please feel free to suggest improvements.