### PR TITLE
Mention `Appsignal.Plug.put_name/1` in Elixir 3.0 upgrade guide

### DIFF
--- a/source/elixir/installation/upgrading-from-1.x-to-2.x.html.md
+++ b/source/elixir/installation/upgrading-from-1.x-to-2.x.html.md
@@ -111,8 +111,33 @@ end
 Lastly, query instrumentation is automatic in 2.x, so you can remove the
 `:telemetry.attach/4` call in your application module.
 
+## Custom instrumentation
+
+If you use `Appsignal.Transaction.set_action/1` to override action names for actions in your Plug or Phoenix app, switch to the newly added `Appsignal.Plug.put_name/2` which adds the new name to the conn. You'll have to make sure you call `put_name/2` on the conn that's returned in the action:
+
+```elixir
+defmodule AppsignalPlugExample do
+  use Plug.Router
+  use Appsignal.Plug
+  plug(:match)
+  plug(:dispatch)
+
+  get "/" do
+    conn
+    |> Appsignal.Plug.put_name("AppsignalPlugExample#index")
+    |> send_resp(200, "Welcome")
+  end
+end
+```
+
+For pure Elixir apps, you can use `Appsignal.Span.set_name/2` to set the name directly on the current span:
+
+```elixir
+Appsignal.Span.set_name(Appsignal.Tracer.current_span(), "AppsignalElixirExample#index")
+```
+
+If your app includes more custom instrumentation, please check out the [custom instrumentation documentation](https://docs.appsignal.com/elixir/instrumentation/) for more information about custom instrumentation in 2.x.
+
 ## Welcome to 2.x!
 
-This should cover upgrading most Phoenix applications to 2.x. If your app includes custom instrumentation, please check out the [custom instrumentation documentation](https://docs.appsignal.com/elixir/instrumentation/) for more information about custom instrumentation in 2.x.
-
-If you have any questions, or would like assistance upgrading to the new version, please don't hesitate to [contact support](mailto:support@appsignal.com).
+This should cover upgrading most Phoenix applications to 2.x. If you have any questions, or would like assistance upgrading to the new version, please don't hesitate to [contact support](mailto:support@appsignal.com).


### PR DESCRIPTION
As reported in https://github.com/appsignal/appsignal-elixir/issues/587, the
upgrade guide doesn't mention what to do with
`Appsignal.Transaction.set_name/1`. This patch adds an explanation to point
users to `Appsignal.Plug.put_name/1`.