### PR TITLE
Add missing backtick to upgrade guide

### DIFF
--- a/source/elixir/installation/upgrading-from-1.x-to-2.x.html.md
+++ b/source/elixir/installation/upgrading-from-1.x-to-2.x.html.md
@@ -78,7 +78,7 @@ Instead of the custom `:template_engines` from 1.x, AppSignal for Elixir 2.x
 uses the new `Appsignal.View` module to gain insights into your template
 rendering.
 
-To upgrade, remove the `:template_engines` from `config/config.exs and add `use
+To upgrade, remove the `:template_engines` from `config/config.exs` and add `use
 Appsignal.Phoenix.View` to the view/0 function in your app's web module, after
 `use Phoenix.View`:
 


### PR DESCRIPTION
Minor inconvenience I noticed while reading through the guide.
The missing backtick causes the text to be highlighted instead of the inline code.