### PR TITLE
Remove Ruby's garbage collection config option

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -340,14 +340,6 @@ options:
       default_value: false
       description: |
         Enable the experimental front-end error catching system. This will add a route to your app on `/appsignal_error_catcher` that can be used to catch JavaScript error and send them to AppSignal. You can configure this route with [`frontend_error_catching_path`](#option-frontend_error_catching_path).
-  - config_key: enable_gc_instrumentation
-    env_key: APPSIGNAL_ENABLE_GC_INSTRUMENTATION
-    ruby:
-      since: 1.0.0
-      type: bool
-      default_value: false
-      description: |
-        Set this option to `true` to enable AppSignal instrumentation of Ruby's Garbage Collection.
   - config_key: enable_host_metrics
     env_key: APPSIGNAL_ENABLE_HOST_METRICS
     ruby:


### PR DESCRIPTION
Removing Ruby's garbage collection config option since the feature still requires some work.