### PR TITLE
Update appsignal absinthe plug to 2.x

### DIFF
--- a/source/elixir/integrations/absinthe.html.md
+++ b/source/elixir/integrations/absinthe.html.md
@@ -4,7 +4,7 @@ title: "Absinthe <sup>Unofficial support</sup>"
 
 !> **Warning:** Use this solution at your own risk.
 
-!> **Warning:** This solution was updated to work with AppSignal Elixir package version 1.5.0 and newer. The old version, previously documented here, doesn't work on newer packages anymore.
+!> **Warning:** This solution was updated to work with AppSignal Elixir package version 2.0.0 and newer. The old version, previously documented here, doesn't work on newer packages anymore.
 
 -> **Note:** AppSignal for Elixir doesn't officially integrate with Absinthe, please track our progress on adding other integrations in [this GitHub issue](https://github.com/appsignal/appsignal-elixir/issues/176).
 
@@ -33,8 +33,8 @@ defmodule AppsignalAbsinthePlug do
 
   @path "/graphql" # Change me to your route's path
   def call(%Plug.Conn{request_path: @path, method: "POST"} = conn, _) do
-    Transaction.set_action("POST " <> @path)
     conn
+    |> Appsignal.Plug.put_name("POST " <> @path)
   end
 
   def call(conn, _) do


### PR DESCRIPTION
After version `2.x.x` the documented solution stopped working. Instead of simply replacing `Transaction.set_action/1` to `Appsignal.Plug.put_name/2` it is also important to return the new `Plug.Conn` struct (containing private attribute `:appsignal_name`) inside plug `call/2` otherwise it won't work.




