### PR TITLE
Document Ruby gem 3.0 changes, add upgrade guide

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -336,6 +336,8 @@ options:
     env_key: APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING
     ruby:
       since: 1.0.0
+      since_notes:
+        - "`3.0.0`: Removed from the gem. See our [upgrade guide](/ruby/installation/upgrade-from-2-to-3.html) for more information."
       type: bool
       default_value: false
       description: |

--- a/data/navigation.yml
+++ b/data/navigation.yml
@@ -231,6 +231,9 @@ sections:
               -
                 name: "Overview"
                 link: "/ruby/installation/"
+              -
+                name: "Upgrading from 2 to 3"
+                link: "/ruby/installation/upgrade-from-2-to-3.html"
           -
             name: "Configuration"
             link: "/ruby/configuration/"

--- a/source/ruby/installation/upgrade-from-2-to-3.html.md
+++ b/source/ruby/installation/upgrade-from-2-to-3.html.md
@@ -34,7 +34,9 @@ Other instrumentation gems may either use the method aliasing or `Module.prepend
 
 The Ruby ecosystem seems to be moving towards the `Module.prepend` method of providing instrumentation so the AppSignal gem has updated its instrumentation method to be more compatible with other gems.
 
-If an app encounters this issue with the AppSignal for Ruby 3.x series, please contact the maintainers of the other gems to update their implementation to `Module.prepend`, and downgrade the AppSignal for Ruby gem to the 2.x series for now. Please also [inform us][contact], so we can keep a list of compatible gems.
+If an app starts encountering this issue with the AppSignal for Ruby 3.x series, upgrade other APM and error reporting gems in the app. They may have been updated to instrument using `Module.prepend` as well.
+
+If the issue persists, please contact the maintainers of the other gems to update their implementation to `Module.prepend`, and downgrade the AppSignal for Ruby gem to the 2.x series for now. Please also [inform us][contact], so we can keep a list of compatible gems.
 
 For more information and background of this change, see [issue 603 on the Ruby gem issue tracker][module prepend issue].
 

--- a/source/ruby/installation/upgrade-from-2-to-3.html.md
+++ b/source/ruby/installation/upgrade-from-2-to-3.html.md
@@ -1,0 +1,84 @@
+---
+title: "Upgrade from AppSignal for Ruby gem 2.x to 3.x"
+---
+
+AppSignal for Ruby 3.0 is a major release as it changes the way it instruments other gems, removes support for older Ruby versions, removes the integrated JavaScript integration and removes previously deprecated modules. Follow this guide to make the upgrade process smoother.
+
+## Upgrade to the latest 2.x series
+
+Before upgrading to AppSignal for Ruby gem 3.0, please first upgrade to the latest gem from the 2.x series. This version will log and print deprecation warnings for things that will be removed in version 3.x of the gem. Run the tests for your app the gem is integrated with, fix any deprecation warnings and errors you may encounter. This upgrade step will make upgrading an easier process.
+
+First, in the app's `Gemfile`, update the version lock to `~> 2.0` and run `bundle update appsignal` in a terminal in the same directory as the `Gemfile`.
+
+```ruby
+# Gemfile
+
+gem "appsignal", "~> 2.0"
+```
+
+After all deprecation warnings have been resolved that appeared during testing and running the app, remove the version lock from the `Gemfile` and run `bundle update appsignal` again to update to AppSignal for Ruby 3.0.
+
+## Removed Ruby 1.9 supported
+
+The 3.x series of the Ruby gem will no longer support Ruby 1.9 and older versions. Ruby 1.9 has been End of Life since [23th of February 2015](https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/) and should no longer be used in production. Future versions of the AppSignal for Ruby gem may drop other End of Life versions of Ruby.
+
+Please upgrade to a newer version of Ruby to continue using AppSignal for Ruby moving forward.
+
+## Compatibility with other instrumentation gems
+
+In the 3.x series the AppSignal for Ruby gem changed the internals of all its integrations of other gems. Instead of aliasing methods to provide instrumentation, the 3.x series uses `Module.prepend` (introduced in Ruby 2.0), a method to include Ruby Modules in classes and ensuring the included module gets called first.
+
+__What does this means for your apps?__
+
+Other instrumentation gems may either use the method aliasing or `Module.prepend` method to providing instrumentation. These instrumentation methods are __incompatible__ with one another if used on the same Ruby methods. If one gem uses method aliasing, and another `Module.prepend` the app will be caught in a loop and raise a [`stack level too deep (SystemStackError)`][module prepend issue].
+
+The Ruby ecosystem seems to be moving towards the `Module.prepend` method of providing instrumentation so the AppSignal gem has updated its instrumentation method to be more compatible with other gems.
+
+If an app encounters this issue with the AppSignal for Ruby 3.x series, please contact the maintainers of the other gems to update their implementation to `Module.prepend`, and downgrade the AppSignal for Ruby gem to the 2.x series for now. Please also [inform us][contact], so we can keep a list of compatible gems.
+
+For more information and background of this change, see [issue 603 on the Ruby gem issue tracker][module prepend issue].
+
+## Moved modules
+
+Some modules in the gem have been moved or renamed. The 2.x series of the gem will print a warning if it encounters any with the new location of the called module. This warning is printed by a fallback when the old module name is called. This warning will no longer be printed if the new module name is being called instead.
+
+If an app extended or monkeypatched an AppSignal module, the module name needs to be updated for the patch to work again. Do be warned that we do provide support for these patches. If a private module has been removed without replacement, we do not provide the integration any more or it has been merged into another module.
+
+## Removed JavaScript integration
+
+The AppSignal for Ruby gem included a JavaScript exception tracking middleware, which has been removed in the 3.x series. Instead we recommend you use our dedicated [AppSignal for Front-end JavaScript integration](/front-end/).
+
+### Removed options
+
+The following options will no longer affect the AppSignal for Ruby gem, it can be removed from your apps.
+
+- `enable_frontend_error_catching` - removed config option
+  - `APPSIGNAL_ENABLE_FRONTEND_ERROR_CATCHING` - removed environment variable config option
+- `frontend_error_catching_path` - removed config option
+  - `APPSIGNAL_FRONTEND_ERROR_CATCHING_PATH` - removed environment variable config option
+
+### Removed classes
+
+The following classes have been removed from the Ruby gem and calling them will result in a `NameError`.
+
+- `Appsignal::JSExceptionTransaction` - removed JavaScript transaction class
+- `Appsignal::Rack::JSExceptionCatcher` - removed middleware
+
+## Removed `appsignal notify_of_deploy` command
+
+The `appsignal notify_of_deploy` command has been removed. Instead we recommend using the [`revision`](/ruby/configuration/options.html#option-revision) config option to report deploys more accurately. For more information on the topic of deploy markers, please see our [deploy markers section](/application/markers/deploy-markers.html).
+
+If the `revision` option is not a good replacement for your deploy method, please use our [deploy markers API page](/api/markers.html) about how to send the request to notify AppSignal of deploys. And see our [Push & deploy page](https://appsignal.com/redirect-to/app?to=info) for your app for an example using your app's config.
+
+## Removed deprecations
+
+In AppSignal for Ruby 2.x series and older, some behavior of the AppSignal gem may have been deprecated. Most of these deprecations have been removed in the 3.x series.
+
+On the latest release in the AppSignal for Ruby 2.x series, all these deprecations should print an warning to STDERR and to the [`appsignal.log`](/support/debugging.html#log-location) when still used. Please check the app output and logs while on the latest 2.x series gem and fix all deprecation warnings before upgrading. Each deprecation should print/log a warning with the changes needed to resolve the warning.
+
+## Welcome to 3.x!
+
+This guide should cover upgrading most Ruby applications to 3.x. If you have any questions, ran into errors, or would like assistance upgrading to the new version, please don't hesitate to [contact support][contact].
+
+[contact]: mailto:support@appsignal.com
+[module prepend issue]: https://github.com/appsignal/appsignal-ruby/issues/603

--- a/source/ruby/instrumentation/exception-handling.html.md
+++ b/source/ruby/instrumentation/exception-handling.html.md
@@ -132,14 +132,34 @@ Appsignal.monitor_transaction "process_action" do
 end
 ```
 
--> **Note:** This method only works when there is an AppSignal transaction active. Otherwise the error will be ignored. This is true in most automatically supported integrations and when using `Appsignal.monitor_transaction`. Please see [`Appsignal.send_error`](#appsignal-send_error) for sending errors
-without an AppSignal transaction.
+-> **Note:** This method only works when there is an AppSignal transaction active. Otherwise the error will be ignored. This is true in most automatically supported integrations and when using `Appsignal.monitor_transaction`. Please see [`Appsignal.send_error`](#appsignal-send_error) for sending errors without an AppSignal transaction.
 
-###^appsignal-set_error Tagging
+###^appsignal-set_error Adding metadata
 
-Optionally you can can pass in a hash with tags as the second argument.
+-> **Note**: The block argument to `set_error` was added in AppSignal for Ruby gem 3.0.0. If using an older version, use the [metadata arguments](#appsignal-set_error-tagging) instead.
 
 See our [Tagging guide](tagging.html) for more information about the tagging parameter data structure.
+
+```ruby
+begin
+  # some code
+rescue => error
+  Appsignal.set_error(error) do |transaction|
+    transaction.set_namespace("admin")
+    transaction.set_tags(:key => "value")
+  end
+end
+```
+
+###^appsignal-set_error-metadata Tagging
+
+!> **Warning**: The tags argument was deprecated in AppSignal for Ruby gem 3.0.0. Instead use the [block argument](#appsignal-set_error-adding-metadata) for `set_error`.
+
+-> **Note**: The tags argument is available since version 2.3.0 of the AppSignal for Ruby gem.
+
+-> 📖 See our [Tagging guide](tagging.html) for more information about the tagging parameter data structure.
+
+Optionally you can can pass in a hash with tags as the second argument.
 
 ```ruby
 begin
@@ -149,13 +169,16 @@ rescue => e
 end
 ```
 
--> **Note**: Tagging argument is available since version 2.3.0 of the AppSignal for Ruby gem.
-
 ###^appsignal-set_error Namespaces
+
+!> **Warning**: The namespace argument was deprecated in AppSignal for Ruby gem 3.0.0. Instead use the [block argument](#appsignal-set_error-adding-metadata) for `set_error`.
+
+-> **Note**: Namespaces argument is available since version 2.3.0 of the AppSignal for Ruby gem.
+
+-> 📖 See our [Namespaces](/application/namespaces.html) page for more information about using namespaces.
 
 Optionally you can can pass in custom namespace name as the third argument. This error will then be reported under the specified namespace rather than the default namespace.
 
-See our [Namespaces](/application/namespaces.html) page for more information about using namespaces.
 
 ```ruby
 begin
@@ -164,8 +187,6 @@ rescue => e
   Appsignal.set_error(e, {}, "admin")
 end
 ```
-
--> **Note**: Namespaces argument is available since version 2.3.0 of the AppSignal for Ruby gem.
 
 ## Appsignal.send_error
 
@@ -184,6 +205,10 @@ rescue => e
   Appsignal.send_error(e)
 end
 ```
+
+###^appsignal-send_error Adding metadata
+
+-> **Note**: The block argument to `send_error` was added in AppSignal for Ruby gem 2.9.0. If using an older version, use the [metadata arguments](#appsignal-send_error-tagging) instead.
 
 In AppSignal for Ruby gem 2.9 and newer an additional block can be passed to the `Appsignal.send_error` method to add more metadata to the error transaction. This includes metadata such as the action name and parameters. Older versions of the Ruby gem will not allow additional metadata to be set.
 
@@ -220,9 +245,11 @@ For another example of `Appsignal.send_error` in such a context see our [Rake in
 
 ###^appsignal-send_error Tagging
 
-Optionally you can can pass in a hash with tags as the second argument.
+!> **Warning**: The tags argument was deprecated in AppSignal for Ruby gem 3.0.0. Instead use the [block argument](#appsignal-send_error-adding-metadata) for `send_error`.
 
-See our [Tagging guide](tagging.html) for more information about the tagging parameter data structure.
+-> 📖 See our [Tagging guide](tagging.html) for more information about the tagging parameter data structure.
+
+Optionally you can can pass in a hash with tags as the second argument.
 
 ```ruby
 begin
@@ -234,9 +261,12 @@ end
 
 ###^appsignal-send_error Namespaces
 
+!> **Warning**: The namespace argument was deprecated in AppSignal for Ruby gem 3.0.0. Instead use the [block argument](#appsignal-send_error-adding-metadata) for `send_error`.
+
+-> 📖 See our [Namespaces](/application/namespaces.html) page for more information about using namespaces.
+
 Optionally you can can pass in custom namespace name as the third argument. This error will then be reported under the specified namespace rather than the default namespace.
 
-See our [Namespaces](/application/namespaces.html) page for more information about using namespaces.
 
 ```ruby
 begin

--- a/source/ruby/integrations/rake.html.md
+++ b/source/ruby/integrations/rake.html.md
@@ -70,7 +70,7 @@ task :foo do
 end
 ```
 
-Tasks that do not raise an error, but call `Appsignal.send_error` or any of the [custom metrics](/metrics/custom.html) helper methods, need to call `Appsignal.stop` after the task is finished.
+Tasks that do not raise an error, but call [`Appsignal.send_error`](/ruby/instrumentation/exception-handling.html#appsignal-send_error) or any of the [custom metrics](/metrics/custom.html) helper methods, need to call `Appsignal.stop` after the task is finished.
 
 ```ruby
 # Rakefile

--- a/source/ruby/integrations/sidekiq.html.md
+++ b/source/ruby/integrations/sidekiq.html.md
@@ -53,6 +53,12 @@ Sidekiq.on(:shutdown) do
 end
 ```
 
+## Internal Sidekiq errors
+
+-> ℹ️ This type of error reporting was added in AppSignal for Ruby gem version 3.0.
+
+When Sidekiq encounters a problem before or after a job has been processed, such as parsing JSON from Redis, it will raise an error. This error is reported under the `SidekiqInternal` action on the `background` namespace, as the context of the job is unknown at the time the error occurs.
+
 ## Metrics
 
 The Sidekiq integration will report the following [metrics](/metrics/custom.html) for every processed job.

--- a/source/support/known-issues.html.md
+++ b/source/support/known-issues.html.md
@@ -15,9 +15,9 @@ See also the GitHub issue tracker for our integrations for other known issues:
 ## List of known issues
 
 - [Compatibility issue with other instrumentation gems](known-issues/gem-instrumentation-compatibility.html)
-  - Symptom: Apps produce "SystemStackErrors" when other instrumentation gems are loaded, such as http_logger, bugsnag, datadog and potentially others.
+  - Symptom: Apps produce `SystemStackErrors` when other instrumentation gems are loaded, such as http_logger, Bugsnag, Datadog and potentially other gems.
   - Affected components:
-      - AppSignal for Ruby package versions: `0.0.x` - most recent
+      - AppSignal for Ruby package versions: `0.0.x` - `2.11.x`
 - [Puma phased restart are broken](known-issues/puma-phased-restart.html)
   - Symptom: Puma phased restart are broken.
   - Affected components:

--- a/source/support/known-issues/gem-instrumentation-compatibility.html.md
+++ b/source/support/known-issues/gem-instrumentation-compatibility.html.md
@@ -4,22 +4,29 @@ title: Compatibility issue with other instrumentation gems
 
 ## Affected components
 
-- AppSignal for Ruby, all versions, in combination with:
-  - http_logger gem 0.6.0 and later
-  - Bugsnag gem 6.12.0 and later
-  - Datadog gem
+- AppSignal for Ruby versions: `0.x` - `2.11.x`
+  - Used in combination with:
+    - http_logger gem 0.6.0 and later
+    - Bugsnag gem 6.12.0 and later
+    - Datadog gem
 
 ## Description
 
-Upon executing a rake task or performing a Net::HTTP request the app will raise a "stack level too deep (SystemStackError)" error. There may also be other scenarios where this "SystemStackError" occurs, as it can potentially occur with every type of instrumentation set up by the AppSignal gem and other gems.
+Upon executing a rake task or performing a `Net::HTTP` request the app will raise a `stack level too deep (SystemStackError)` error. There may also be other scenarios where this `SystemStackError` occurs, as it can potentially occur with every type of instrumentation set up by the AppSignal gem and other gems.
 
-This error is caused by the AppSignal gem and other gems with instrumentation having different methods of instrumentation that are incompatible. These different methods cause aliased methods, set up by instrumentation gems, to be continuously called until Ruby's stack has been exhausted.
+This error is caused by the AppSignal Ruby gem and other gems with instrumentation having different methods of instrumentation that are incompatible. These different methods cause aliased methods, set up by instrumentation gems, to be continuously called until Ruby's stack has been exhausted.
 
-We're looking into solutions for this issue in [appsignal-ruby issue #603](https://github.com/appsignal/appsignal-ruby/issues/603). This issue also contains more information about the cause of the issue and potential solutions. Please report issues with other gems if encountered in this issue.
+We've have discussed a solution for this issue in [appsignal-ruby issue #603](https://github.com/appsignal/appsignal-ruby/issues/603). This issue also contains more information about the cause of the issue and potential solutions. Please report issues with other gems if encountered in this issue.
+
+## Solution
+
+Upgrade to the AppSignal for Ruby gem version `3.0.0` or newer.
+
+See our [upgrade guide to Ruby gem 3.0](/ruby/installation/upgrading-from-2-to-3.html) for more information about this issue and upgrading the AppSignal Ruby gem.
 
 ## Workaround
 
 - Downgrade the Bugsnag library to `6.11.1`.
 - Downgrade the http_logger library to `0.5.1`.
 - Downgrade other gems that introduce the same problem in newer versions.
-- Remove either of the gems until the issue has been resolved.
+- Remove either of the gems until the issue has been resolved in both gems.


### PR DESCRIPTION
Update docs to mention changes in the Ruby 3.0 gem.

Add an upgrade guide to help users guide them through the upgrade. The
most important step though is probably upgrading to the latest 2.x
series gem as that prints and logs warnings for all the things that may
break in Ruby gem 3.0.

Closes #418