### PR TITLE
Namespace in Elixir is added using root_span

### DIFF
--- a/source/guides/namespaces.html.md
+++ b/source/guides/namespaces.html.md
@@ -94,7 +94,7 @@ defmodule AppsignalPhoenixExampleWeb.AdminController do
   defp set_appsignal_namespace(conn, _params) do
     # Configures all actions in this controller to report
     # in the "admin" namespace
-    Appsignal.Span.set_namespace(Appsignal.Tracer.current_span(), "admin")
+    Appsignal.Span.set_namespace(Appsignal.Tracer.root_span(), "admin")
     conn
   end
 
@@ -108,7 +108,7 @@ In a background job call the `Appsignal.Transaction.set_namespace` at the beginn
 defmodule MyApp.CriticalJob do
   def run do
     # Configures this worker's jobs to report in the "critical" namespace
-    Appsignal.Span.set_namespace(Appsignal.Tracer.current_span(), "critical")
+    Appsignal.Span.set_namespace(Appsignal.Tracer.root_span(), "critical")
 
     # The actual worker code
   end


### PR DESCRIPTION
Updating the instructions on creating a namespace in Elixir integration, instead of `current_span` we need to use `root_span`.