### PR TITLE
Document JSON metrics public endpoint

### DIFF
--- a/data/navigation.yml
+++ b/data/navigation.yml
@@ -669,7 +669,7 @@ sections:
             name: "Installation"
             link: "/standalone-agent/installation.html"
           -
-            name: "StatsD"
+            name: "StatsD Metrics"
             link: "/standalone-agent/statsd.html"
       -
         name: "AppSignal API <sup>Beta</sup>"
@@ -704,6 +704,9 @@ sections:
               -
                 name: "StatsD"
                 link: "/api/public-endpoint/statsd.html"
+              -
+                name: "JSON Metrics"
+                link: "/api/public-endpoint/json-metrics.html"
   -
     name: "More"
     sub_sections:

--- a/source/api/public-endpoint/index.html.md
+++ b/source/api/public-endpoint/index.html.md
@@ -32,4 +32,5 @@ https://appsignal-endpoint.net/metrics/statsd?api_key=<api_key>
 
 This API exposes the following endpoints:
 
-* [StatsD](/api/public-endpoint/statsd.html) Send (batched) StatsD-formatted metrics to AppSignal.
+* [StatsD Metrics](/api/public-endpoint/statsd.html) Send (batched) StatsD-formatted metrics to AppSignal.
+* [JSON Metrics](/api/public-endpoint/json-metrics.html) Send (batched) JSON-formatted metrics to AppSignal.

--- a/source/api/public-endpoint/json-metrics.html.md
+++ b/source/api/public-endpoint/json-metrics.html.md
@@ -1,0 +1,62 @@
+---
+title: "Public Endpoint - JSON Metrics"
+---
+
+This API endpoint is provided to add additional metrics to AppSignal, where an existing integration can't be used or the language used isn't supported (yet).
+
+This endpoint is meant for integrations that send aggregated metrics over a small period, it's preferred to send one request every 5 seconds with 100 metrics over 100 requests per 5 minutes with one metric each.
+
+## Endpoint
+
+Request method: `POST`
+
+| Endpoint | Description|
+| --- | --- |
+| https://appsignal-endpoint.net/metrics/json | Accepts JSON formatted data |
+
+## URL parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| api_key | String | **Front-end** API key, can be found in [App settings](https://appsignal.com/redirect-to/app?to=info). |
+
+
+```
+https://appsignal-endpoint.net/metrics/json?api_key=<api_key>
+```
+
+## Body parameters
+
+The post body should contain JSON formatted metrics separated by a newline, or as a full json body.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| name | String | Name of metric, shouldn't contain spaces or special characters, e.g. only (`[a-zA-Z0-9-_]`) |
+| metricType | String | Metric type, can be one of `[gauge, counter, timing, histogram]` |
+| value | Float | (Float) value |
+| tags | Object<String, String> | Object containing tags. Both key and value should be a string, for example: `{ "hostname": "frontend1" }` |
+
+
+Example of JSON body
+
+```json
+[
+  {"name": "traffic_gauge", "metricType": "gauge", "value": 19.8, "tags": {"hostname": "frontend1"}},
+  {"name": "error_counter", "metricType": "counter", "value": 10, "tags": {"hostname": "frontend1", "disk": "vda"}},
+  {"name": "duration_timing", "metricType": "timing", "value": 19, "tags": {"lambda": "login"}},
+  {"name": "duration_timing", "metricType": "histogram", "value": 5, "tags": {"lambda": "login"}}
+]
+```
+
+
+Example of newline-separated body:
+
+```
+{"name": "traffic_gauge", "metricType": "gauge", "value": 19.8, "tags": {"hostname": "frontend1"}}\n
+{"name": "error_counter", "metricType": "counter", "value": 10, "tags": {"hostname": "frontend1", "disk": "vda"}}\n
+{"name": "duration_timing", "metricType": "timing", "value": 19, "tags": {"lambda": "login"}}\n
+{"name": "duration_timing", "metricType": "histogram", "value": 5, "tags": {"lambda": "login"}}\n
+```
+
+
+-> **Note**: This endpoint is optimized for large amounts of traffic and does not validate the API key or payload, a `200` (`OK`) response is returned when the body size is within the `200k` limit. This doesn't mean the request is accepted when received.

--- a/source/api/public-endpoint/statsd.html.md
+++ b/source/api/public-endpoint/statsd.html.md
@@ -1,5 +1,5 @@
 ---
-title: "Public Endpoint - StatsD"
+title: "Public Endpoint - StatsD Metrics"
 ---
 
 This StatsD API endpoint is provided to add additional metrics to AppSignal, where an existing integration can't be used or the language used isn't supported (yet).


### PR DESCRIPTION
Adds a documentation page for our public endpoint JSON formatted metrics