### PR TITLE
Improve the overview page of custom integration and tracing

### DIFF
--- a/source/elixir/instrumentation/index.html.md
+++ b/source/elixir/instrumentation/index.html.md
@@ -5,3 +5,15 @@ title: "Custom instrumentation for Elixir"
 AppSignal provides many ways to bring more insights in your application by
 adding more instrumentation or tagging the data that appears in the UI at
 AppSignal.com.
+
+* [Integrating AppSignal](integrating-appsignal.html)
+* [Instrumentation](instrumentation.html)
+* [Exception handling](exception-handling.html)
+* [Minutely probes](minutely-probes.html)
+* [Mix tasks](mix_tasks.html)
+* [Command line tool](/elixir/command-line/index.html)
+
+## Contact us
+
+Don't hesitate to [contact us](mailto:support@appsignal.com) if you run into
+any issues while implementing custom instrumentation. We're here to help.

--- a/source/nodejs/tracing/index.html.md
+++ b/source/nodejs/tracing/index.html.md
@@ -7,3 +7,13 @@ AppSignal provides many ways to provide more insights into your application - by
 **Traces** are made of one or many `Span`s. A Trace can be thought of as a _directed acyclic graph (DAG)_ of `Span`s:
 
 ![Trace diagram](/assets/images/abstract-trace.png)
+
+* [The Tracer object](index.html)
+* [Creat and using a Span](span.html)
+* [Exception handling](exception-handling.html)
+* [Async tracing and Scopes](scopes.html)
+
+## Contact us
+
+Don't hesitate to [contact us](mailto:support@appsignal.com) if you run into
+any issues while implementing tracing. We're here to help.

--- a/source/ruby/instrumentation/index.html.md
+++ b/source/ruby/instrumentation/index.html.md
@@ -5,3 +5,20 @@ title: "Custom instrumentation for Ruby"
 AppSignal provides many ways to provide more insights in your application by
 adding more instrumentation or tagging the data that appears in the UI at
 AppSignal.com.
+
+* [Integrating AppSignal](integrating-appsignal.html)
+* [Instrumentation](instrumentation.html)
+* [Exception handling](exception-handling.html)
+* [Breadcrumbs](breadcrumbs.html)
+* [Ignore instrumentation](ignore-instrumentation.html)
+* [Background jobs](background-jobs.html)
+* [Method instrumentation](method-instrumentation.html)
+* [Event formatters](event-formatters.html)
+* [Minutely probes](minutely-probes.html)
+* [Rerequest queue timeque](request-queue-time.html)
+* [Command line tool](/ruby/command-line/index.html)
+
+## Contact us
+
+Don't hesitate to [contact us](mailto:support@appsignal.com) if you run into
+any issues while implementing custom instrumentation. We're here to help.


### PR DESCRIPTION
The overview page of "Custom instrumentation" (Ruby/Elixir) and "Tracing" (nodejs) was not helpful, I added the table of content to help users navigate to the content related to the topic.