### PR TITLE
Update incorrect Cloud66 documentation

### DIFF
--- a/source/application/markers/deploy-markers.html.md
+++ b/source/application/markers/deploy-markers.html.md
@@ -75,7 +75,8 @@ If you'd like to use the Deploy Marker feature with [Cloud66](https://www.cloud6
 ```yml
 # For Ruby
 # config/appsignal.yml
-revision: "<%= ENV['CLOUD66_SERVICE_GIT_REF'] %>"
+production:
+  revision: "<%= `git log --pretty=format:'%h' -n 1` %>"
 ```
 
 ## Manually create a Deploy marker


### PR DESCRIPTION
The suggested code doesn't work for cloud 66, as the environment variable in the example doesn't seem to exist. I also believe having it as a root-level item in the yaml file doesn't work.

I've replaced it with code that we use within our stack.