### PR TITLE
Mention the order of Appsignal.Phoenix and Plug.Builder

### DIFF
--- a/source/elixir/installation/umbrella.html.md
+++ b/source/elixir/installation/umbrella.html.md
@@ -30,7 +30,7 @@ application](/elixir/integrations/phoenix.html). One thing to keep in mind is
 to `use Appsignal.Phoenix` in your application’s endpoint file. If you have
 multiple nested Phoenix applications, use the module in each.
 
--> If you include use `Plug.Builder` or any other module that redefines the `call/2` function, make sure to place the `use Appsignal.Phoenix` line after that.
+-> If you include `use Plug.Builder` or any other module that redefines the `call/2` function, make sure to place the `use Appsignal.Phoenix` line after that.
 
 ```elixir
 defmodule AppsignalPhoenixExampleWeb.Endpoint do

--- a/source/elixir/installation/umbrella.html.md
+++ b/source/elixir/installation/umbrella.html.md
@@ -27,7 +27,7 @@ By default, each nested application in an umbrella uses the main umbrella config
 The installation for Phoenix in an umbrella application are mostly the same as
 [setting up AppSignal “regular” Phoenix
 application](/elixir/integrations/phoenix.html). One thing to keep in mind is
-to `use Appsignal.Phoenix` in your application’s endpoint file. If you have
+to `use Appsignal.Phoenix` in your application’s endpoint file and add this after `Plug.Builder`. If you have
 multiple nested Phoenix applications, use the module in each.
 
 ```elixir

--- a/source/elixir/installation/umbrella.html.md
+++ b/source/elixir/installation/umbrella.html.md
@@ -27,8 +27,10 @@ By default, each nested application in an umbrella uses the main umbrella config
 The installation for Phoenix in an umbrella application are mostly the same as
 [setting up AppSignal “regular” Phoenix
 application](/elixir/integrations/phoenix.html). One thing to keep in mind is
-to `use Appsignal.Phoenix` in your application’s endpoint file and add this after `Plug.Builder`. If you have
+to `use Appsignal.Phoenix` in your application’s endpoint file. If you have
 multiple nested Phoenix applications, use the module in each.
+
+-> If you include use `Plug.Builder` or any other module that redefines the `call/2` function, make sure to place the `use Appsignal.Phoenix` line after that.
 
 ```elixir
 defmodule AppsignalPhoenixExampleWeb.Endpoint do


### PR DESCRIPTION
`Plug.Builder` redefines the call/2 function we’ve overwritten with the use `Appsignal.Phoenix` call so we need to call`Plug.Builder` before `Appsignal.Phoenix` call. 