### PR TITLE
Fix all links pointing to public pages. point them to www.appsignal.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ documentation and follow our [Code of Conduct][coc].
 Also, we would be very happy to send you Stroopwaffles. Have look at everyone
 we send a package to so far on our [Stroopwaffles page][waffles-page].
 
-[appsignal]: https://appsignal.com
+[appsignal]: https://www.appsignal.com
 [contact]: mailto:support@appsignal.com
 [coc]: https://docs.appsignal.com/appsignal/code-of-conduct.html
-[waffles-page]: https://appsignal.com/waffles
+[waffles-page]: https://www.appsignal.com/waffles
 [docs]: https://docs.appsignal.com
 [contributing-guide]: https://docs.appsignal.com/contributing

--- a/source/_cookies.html.haml
+++ b/source/_cookies.html.haml
@@ -1,3 +1,3 @@
 .mod-cookies
-  %p We'd like to set cookies, #{link_to "read why", "https://appsignal.com/privacy-policy"}.
+  %p We'd like to set cookies, #{link_to "read why", "https://www.appsignal.com/privacy-policy"}.
   %button.button.tiny.accept_link I accept

--- a/source/_footer.html.erb
+++ b/source/_footer.html.erb
@@ -18,7 +18,7 @@
         <div class="w-full lg:w-1/2 p-4 lg:p-8">
           <h1 class="c-heading--2xl">Start a trial - 30 days free</h1>
           <p>AppSignal is a great way to monitor your Ruby, Elixir & Node.js applications. Works great with Rails, Phoenix, Express and other frameworks, with support for background jobs too. Let's improve your apps together.</p>
-          <%= link_to "Start a trial", "https://appsignal.com/plans", :class => "c-button c-button--gray c-button--sm mt-4" %>
+          <%= link_to "Start a trial", "https://www.appsignal.com/plans", :class => "c-button c-button--gray c-button--sm mt-4" %>
         </div>
       </div>
     </div>

--- a/source/_header.html.erb
+++ b/source/_header.html.erb
@@ -50,10 +50,10 @@
     }
   ]
   platforms = [
-    { name: "Elixir APM", link: "https://appsignal.com/elixir/", icon: "fa fa-tint", text_class: "text-purple", dark_text_class: "dark:text-purple-400" },
-    { name: "Ruby APM", link: "https://appsignal.com/ruby/", icon: "fa fa-gem", text_class: "text-red", dark_text_class: "dark:text-red-400" },
-    { name: "NodeJS APM", link: "https://appsignal.com/nodejs/", icon: "fab fa-node-js", text_class: "text-green", dark_text_class: "dark:text-green-400" },
-    { name: "JavaScript error tracking", link: "https://appsignal.com/javascript/", icon: "fab fa-js-square", text_class: "text-yellow", dark_text_class: "dark:text-yellow-400" }
+    { name: "Elixir APM", link: "https://www.appsignal.com/elixir/", icon: "fa fa-tint", text_class: "text-purple", dark_text_class: "dark:text-purple-400" },
+    { name: "Ruby APM", link: "https://www.appsignal.com/ruby/", icon: "fa fa-gem", text_class: "text-red", dark_text_class: "dark:text-red-400" },
+    { name: "NodeJS APM", link: "https://www.appsignal.com/nodejs/", icon: "fab fa-node-js", text_class: "text-green", dark_text_class: "dark:text-green-400" },
+    { name: "JavaScript error tracking", link: "https://www.appsignal.com/javascript/", icon: "fab fa-js-square", text_class: "text-yellow", dark_text_class: "dark:text-yellow-400" }
   ]
 %>
 
@@ -63,7 +63,7 @@
     data-mobile-menu-wrapper-active-classes="fixed inset-0 overflow-y-auto"
   >
     <div class="container flex flex-wrap items-center py-5 px-8">
-      <a href="https://appsignal.com" class="flex-grow lg:flex-grow-0" title="Return to the homepage of AppSignal">
+      <a href="https://www.appsignal.com" class="flex-grow lg:flex-grow-0" title="Return to the homepage of AppSignal">
         <%= image_tag "dl_logo/appsignal-logo.svg", :alt => "Logo of AppSignal", :class => "h-6" %>
       </a>
 
@@ -71,7 +71,7 @@
       <nav class="hidden lg:block flex-grow w-full lg:w-auto mt-6 lg:mt-0">
         <ul class="c-header-nav">
           <li>
-            <a href="https://appsignal.com" class="c-header-nav__link">
+            <a href="https://www.appsignal.com" class="c-header-nav__link">
               Home
             </a>
           </li>
@@ -89,7 +89,7 @@
                   <ul class="c-header-subnav__list c-header-subnav__list--large grid grid-cols-2">
                     <% tours.each do |tour| %>
                       <li class="col-span-1">
-                        <a href="https://appsignal.com/tour/<%= tour[:slug] %>" class="c-header-subnav__link c-header-subnav__link--large">
+                        <a href="https://www.appsignal.com/tour/<%= tour[:slug] %>" class="c-header-subnav__link c-header-subnav__link--large">
                           <i class="fa fa-fw <%= tour[:icon] %> c-header-subnav__link__icon <%= tour[:icon_class] %>"></i>
                           <div>
                             <span class="c-header-subnav__link__title">
@@ -131,7 +131,7 @@
             <a href="http://blog.appsignal.com" class="c-header-nav__link">Blog</a>
           </li>
           <li>
-            <a href="https://appsignal.com/pricing" class="c-header-nav__link">
+            <a href="https://www.appsignal.com/pricing" class="c-header-nav__link">
               Pricing
             </a>
           </li>
@@ -169,7 +169,7 @@
           <h3 class="c-header-m-nav__title">Features</h3>
           <% tours.each do |tour| %>
             <li>
-              <a class="c-header-m-nav__link" href="https://appsignal.com/tour/<%= tour[:slug] %>">
+              <a class="c-header-m-nav__link" href="https://www.appsignal.com/tour/<%= tour[:slug] %>">
                 <i class="c-header-m-nav__link__icon fa fa-fw <%= tour[:icon] %>"></i>
               <span class="c-header-m-nav__link__title">
                 <%= tour[:title] %>
@@ -194,7 +194,7 @@
         <ul class="c-header-m-nav__list">
           <h3 class="c-header-m-nav__title">Product</h3>
           <li>
-            <a class="c-header-m-nav__link" href="https://appsignal.com/pricing">
+            <a class="c-header-m-nav__link" href="https://www.appsignal.com/pricing">
               <i class="c-header-m-nav__link__icon fa fa-fw fa-credit-card-blank"></i>
               <span class="c-header-m-nav__link__title">
                 Pricing

--- a/source/_header.html.erb
+++ b/source/_header.html.erb
@@ -131,7 +131,7 @@
             <a href="http://blog.appsignal.com" class="c-header-nav__link">Blog</a>
           </li>
           <li>
-            <a href="https://www.appsignal.com/pricing" class="c-header-nav__link">
+            <a href="https://www.appsignal.com/plans" class="c-header-nav__link">
               Pricing
             </a>
           </li>
@@ -194,7 +194,7 @@
         <ul class="c-header-m-nav__list">
           <h3 class="c-header-m-nav__title">Product</h3>
           <li>
-            <a class="c-header-m-nav__link" href="https://www.appsignal.com/pricing">
+            <a class="c-header-m-nav__link" href="https://www.appsignal.com/plans">
               <i class="c-header-m-nav__link__icon fa fa-fw fa-credit-card-blank"></i>
               <span class="c-header-m-nav__link__title">
                 Pricing

--- a/source/appsignal/contributing/index.html.md
+++ b/source/appsignal/contributing/index.html.md
@@ -27,13 +27,13 @@ Our main projects include:
 Other projects we have open sourced, and are used internally by other projects,
 include:
 
-- [AppSignal Rust agent][appsignal-rust]  
+- [AppSignal Rust agent][appsignal-rust]
   Early stage proof of concept of AppSignal Rust integration.
-- [sql_lexer][sql_lexer]  
+- [sql_lexer][sql_lexer]
   Rust library to lex and sanitize SQL queries.
-- [probes.rs][probes-rs]  
+- [probes.rs][probes-rs]
   Rust library to read out system stats from a machine running Linux.
-- [public_config][public_config]  
+- [public_config][public_config]
   Parts of AppSignal.com configuration that are public, such as magic dashboards.
 
 ## Using git and GitHub
@@ -100,8 +100,8 @@ behavior to [contact@appsignal.com][coc-contact].
 
 [contact]: mailto:support@appsignal.com
 [blog]: http://blog.appsignal.com/
-[changelog]: https://appsignal.com/changelog
-[waffles-page]: https://appsignal.com/waffles
+[changelog]: https://www.appsignal.com/changelog
+[waffles-page]: https://www.appsignal.com/waffles
 [appsignal-ruby]: https://github.com/appsignal/appsignal-ruby
 [appsignal-elixir]: https://github.com/appsignal/appsignal-elixir
 [appsignal-javascript]: https://github.com/appsignal/appsignal-javascript

--- a/source/appsignal/gdpr.html.md
+++ b/source/appsignal/gdpr.html.md
@@ -24,7 +24,7 @@ AppSignal is the Data Controller for the information we collect about our custom
 
 When sharing data with vendors, we have made sure there are contracts in place that ensure they also receive and process this data in a lawful way.
 
-You can read more about the data we collect for which purpose in our new [Privacy Policy](https://appsignal.com/privacy-policy).
+You can read more about the data we collect for which purpose in our new [Privacy Policy](https://www.appsignal.com/privacy-policy).
 
 ### Data Processor
 

--- a/source/appsignal/terminology.html.md
+++ b/source/appsignal/terminology.html.md
@@ -219,7 +219,7 @@ Learn more about what [CPU metrics](https://blog.appsignal.com/2018/03/06/unders
 Want to learn more about Elixir? In our email series Elixir Alchemy (1x p/mo)
 we dive deeper into Elixir and Erlang.
 You can sign up here:
-[appsignal.com/elixir-alchemy](https://www.appsignal.com/elixir-alchemy).
+[appsignal.com/elixir-alchemy](https://blog.appsignal.com/elixir-alchemy).
 
 ## Environments
 
@@ -480,7 +480,7 @@ performance issues and in graphs for controllers/jobs and on host-level.
 Did you know we write articles about the magic that is Ruby? We do!
 
 It's called Ruby Magic and you can sign up for it on
-[appsignal.com/ruby-magic](https://www.appsignal.com/ruby-magic).
+[appsignal.com/ruby-magic](https://blog.appsignal.com/ruby-magic).
 
 A list of all the Ruby Magic articles we've written so far can be found on [our
 blog](http://blog.appsignal.com/).

--- a/source/appsignal/terminology.html.md
+++ b/source/appsignal/terminology.html.md
@@ -175,7 +175,7 @@ stroopwafels](http://blog.appsignal.com/blog/2016/02/01/stroopwafels-and-how-to-
 ## Changelog
 
 We keep a full product changelog at
-[appsignal.com/changelog](https://appsignal.com/changelog).
+[appsignal.com/changelog](https://www.appsignal.com/changelog).
 
 All our new features, agent releases and other changes to the product can be
 found in this neatly organized list.
@@ -219,7 +219,7 @@ Learn more about what [CPU metrics](https://blog.appsignal.com/2018/03/06/unders
 Want to learn more about Elixir? In our email series Elixir Alchemy (1x p/mo)
 we dive deeper into Elixir and Erlang.
 You can sign up here:
-[appsignal.com/elixir-alchemy](https://appsignal.com/elixir-alchemy).
+[appsignal.com/elixir-alchemy](https://www.appsignal.com/elixir-alchemy).
 
 ## Environments
 
@@ -243,7 +243,7 @@ crash or a simple typo causing an error page.
 Once an error occurs in an application AppSignal sends an alerts and records
 the details of the error for later viewing on AppSignal.com.
 
-Read more about the [errors feature](https://appsignal.com/tour/errors) on our
+Read more about the [errors feature](https://www.appsignal.com/tour/errors) on our
 tour page. To learn more about error handling in Ruby, read our [Exception
 handling](/ruby/instrumentation/exception-handling.html) topic describing how
 to effectively track errors with AppSignal.
@@ -374,7 +374,7 @@ such as [CPU usage](#cpu-usage), load averages, memory usage, etc. gives more
 insight on performance issues than just the code itself. Maybe the disk space
 is running out causing the application to run much slower.
 
-Read more about [metrics](https://appsignal.com/for/metrics) on our tour page.
+Read more about [metrics](https://www.appsignal.com/for/metrics) on our tour page.
 
 ## Namespace
 
@@ -435,7 +435,7 @@ When AppSignal detects a slow web request or operation it will send an alert,
 because slow code can be as damaging as an [error](#errors) appearing.
 
 Read more about the [performance
-feature](https://appsignal.com/for/performance) on our tour page.
+feature](https://www.appsignal.com/for/performance) on our tour page.
 
 ## Push API
 
@@ -480,7 +480,7 @@ performance issues and in graphs for controllers/jobs and on host-level.
 Did you know we write articles about the magic that is Ruby? We do!
 
 It's called Ruby Magic and you can sign up for it on
-[appsignal.com/ruby-magic](https://appsignal.com/ruby-magic).
+[appsignal.com/ruby-magic](https://www.appsignal.com/ruby-magic).
 
 A list of all the Ruby Magic articles we've written so far can be found on [our
 blog](http://blog.appsignal.com/).

--- a/source/guides/filter-data/ignore-actions.html.md
+++ b/source/guides/filter-data/ignore-actions.html.md
@@ -8,7 +8,7 @@ In an app there may be certain actions that you don't want to report to AppSigna
 
 ## Ignoring actions
 
-These actions can be ignored by customizing the configuration for AppSignal integrations in apps. The "ignore actions" configuration option will allow you to configure a list of action names, as reported to AppSignal. Any action in this list will be ignored, meaning the data from these actions will not be sent to the AppSignal servers, and will not count towards your [organization's billing plan](https://appsignal.com/plans).
+These actions can be ignored by customizing the configuration for AppSignal integrations in apps. The "ignore actions" configuration option will allow you to configure a list of action names, as reported to AppSignal. Any action in this list will be ignored, meaning the data from these actions will not be sent to the AppSignal servers, and will not count towards your [organization's billing plan](https://www.appsignal.com/plans).
 
 The "ignore actions" config option is configured differently per integration language. See the list of integrations below for the one your app uses.
 

--- a/source/guides/filter-data/ignore-namespaces.html.md
+++ b/source/guides/filter-data/ignore-namespaces.html.md
@@ -8,7 +8,7 @@ In a previous guide we've discussed [setting up custom namespaces](/guides/names
 
 ## Ignoring namespaces
 
-Namespaces can be ignored by customizing the configuration for AppSignal integrations in apps. The "ignore namespaces" configuration option will allow you to configure a list of namespaces, as reported to AppSignal. Any namespaces in this list will be ignored, meaning the data from these actions will not be sent to the AppSignal servers, and will not count towards your [organization's billing plan](https://appsignal.com/plans).
+Namespaces can be ignored by customizing the configuration for AppSignal integrations in apps. The "ignore namespaces" configuration option will allow you to configure a list of namespaces, as reported to AppSignal. Any namespaces in this list will be ignored, meaning the data from these actions will not be sent to the AppSignal servers, and will not count towards your [organization's billing plan](https://www.appsignal.com/plans).
 
 The "ignore namespaces" config option is configured differently per integration language. See the list of integrations below for the one your app uses.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -3,7 +3,7 @@ title: "AppSignal documentation"
 title_no_brand: true
 ---
 
-Welcome to the [AppSignal](https://appsignal.com) documentation!
+Welcome to the [AppSignal](https://www.appsignal.com) documentation!
 
 In this documentation we aim to give you all the information you need to get started, get the most out of the features and integrate your stuff with our API. Click on a topic on the left in the navigation sidebar to expand it and see more pages about this topic.
 

--- a/source/metrics/host-metrics/index.html.md
+++ b/source/metrics/host-metrics/index.html.md
@@ -4,7 +4,7 @@ title: "Host metrics"
 
 The AppSignal agent collects various system metrics, which allows you to correlate performance issues and errors to abnormal host metrics. This data is available in the [Host metrics](https://appsignal.com/redirect-to/app?to=host_metrics) section in the app overview, which allows you to inspect and [compare multiple hosts](https://blog.appsignal.com/2018/02/20/comparing-hosts.html). We also show a host metrics overview on the sample detail page for error and performance incidents.
 
-For a preview of how host metrics look in the AppSignal interface, please see our [host metrics](https://appsignal.com/tour/hosts) tour page.
+For a preview of how host metrics look in the AppSignal interface, please see our [host metrics](https://www.appsignal.com/tour/hosts) tour page.
 
 -> **Note**: This feature is available in these packages:
 -> <ul>


### PR DESCRIPTION
Fix links pointing to appsignal.com public pages, they now live on www.appsignal.com