### PR TITLE
We do not store data from cookies

### DIFF
--- a/source/application/tagging.html.md
+++ b/source/application/tagging.html.md
@@ -27,7 +27,7 @@ Tags are a great way to pass along the additional details however they are limit
 There are 4 kind of sample data.
 
 1. Session data
-    * This stores the session/cookie data by default; you do not have to pass these in explicitly. AppSignal picks these up automatically (if you are using frameworks), 
+    * This stores the session data by default; you do not have to pass these in explicitly. AppSignal picks these up automatically (if you are using frameworks), 
 2. Params
    * If you are using Ruby on Rails or a Phoenix framework, then AppSignal will fill in the action params for you here automatically.
 3. Environment

--- a/source/guides/custom-data/sample-data.html.md
+++ b/source/guides/custom-data/sample-data.html.md
@@ -62,7 +62,7 @@ The first argument to `setSampleData` takes a `key`, that can be one of the foll
 
 ### `session_data`
 
-Filled with session/cookie data by default, but can be overridden with the following call:
+Filled with session data by default, but can be overridden with the following call:
 
 ```js
 span.setSampleData("session_data", {


### PR DESCRIPTION
We don’t record cookies, only session data, as cookies are stored on the client-side, in any of our integrations.