### PR TITLE
Remove unimplemented docs about Node.js features

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -216,6 +216,7 @@ options:
       type: bool
       default_value: false
     nodejs:
+      configKey: transactionDebugMode
       since: 2.2.4
       type: bool
       default_value: false
@@ -471,6 +472,7 @@ options:
       type: bool
       default_value: true
     nodejs:
+      config_key: filesWorldAccessible
       since: 2.2.4
       type: bool
       default_value: true

--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -517,14 +517,6 @@ options:
         ```
 
         Read more about [parameter filtering](/elixir/configuration/parameter-filtering.html).
-    nodejs:
-      config_key: filterParameters
-      type:
-        list:
-          - string
-      default_value: []
-      description: |
-        List of parameter keys that should be ignored using AppSignal filtering. Their values will be replaced with `[FILTERED]` when transmitted to AppSignal.
   - config_key: filter_session_data
     env_key: APPSIGNAL_FILTER_SESSION_DATA
     ruby:
@@ -567,14 +559,6 @@ options:
         ```
 
         Read more about [session data filtering](/elixir/configuration/session-data-filtering.html).
-    nodejs:
-      config_key: filterSessionData
-      type:
-        list:
-          - string
-      default_value: []
-      description: |
-        List of session data keys that should be ignored using AppSignal filtering. Their values will be replaced with `[FILTERED]` when transmitted to AppSignal.
   - config_key: hostname
     env_key: APPSIGNAL_HOSTNAME
     ruby:

--- a/source/guides/filter-data/filter-session-data.html.md
+++ b/source/guides/filter-data/filter-session-data.html.md
@@ -64,22 +64,6 @@ config :appsignal, :config,
   filter_session_data: ["name", "email", "api_token", "token"]
 ```
 
-## Node.js
-
-In the Node.js integration, AppSignal automatically stores the contents of the user's session for certain integrations. Specific values can be filtered out or it can be [disabled entirely].
-
-To use this filtering, add the following to your AppSignal configuration file. The [`filterSessionData`](/nodejs/configuration/options.html#option-filterSessionData) value is an Array of Strings.
-
-```js
-// Example: appsignal.js
-const { Appsignal } = require("@appsignal/nodejs");
-
-const appsignal = new Appsignal({
-  // Other config
-  filterSessionData: ["name", "email", "api_token", "token"]
-});
-```
-
 ## Next steps
 
 - [Request headers collection](/guides/filter-data/filter-headers.html) - the next step in this guide


### PR DESCRIPTION
## Fix config options naming for Node.js

`filesWorldAccessible` and `transactionDebugMode` were shown in camel
case in the Node.js docs.

## Remove info from unimplemented features in Node.js

Node.js lacks the implementation for `filterParameters` and
`filterSessionData`. Documentation about this is deleted until we have
it properly implemented.