### PR TITLE
Update Elixir docs

### DIFF
--- a/source/elixir/1.x/installation/umbrella.html.md
+++ b/source/elixir/1.x/installation/umbrella.html.md
@@ -12,7 +12,9 @@ Add the AppSignal dependency to each application that will use it. This includes
 
 ```elixir
 defp deps do
-  {:appsignal, "~> 1.0"}
+  [
+    {:appsignal, "~> 1.0"}
+  ]
 end
 ```
 

--- a/source/elixir/1.x/installation/upgrading-from-1.x-to-2.x.html.md
+++ b/source/elixir/1.x/installation/upgrading-from-1.x-to-2.x.html.md
@@ -24,7 +24,9 @@ existing dependency on `:appsignal`, and replace it with a dependency on
 
 ```elixir
 defp deps do
-  {:appsignal_phoenix, "~> 2.0.0-beta.1"}
+  [
+    {:appsignal_phoenix, "~> 2.0.0-beta.1"}
+  ]
 end
 ```
 

--- a/source/elixir/installation/index.html.md
+++ b/source/elixir/installation/index.html.md
@@ -34,7 +34,7 @@ Before you can compile the AppSignal package, make sure the build/compilation to
 
 2. Then run `mix deps.get`.
 3. Then run `mix appsignal.install YOUR_PUSH_API_KEY` or follow the [manual configuration guide](#configuration).
-4. If you use the [Phoenix framework][phoenix], continue with the [integrating AppSignal into Phoenix](/elixir/integrations/phoenix.html) guide.
+4. If you use the [Phoenix framework][phoenix] or [Plug][plug], continue with the [integrating AppSignal into Phoenix](/elixir/integrations/phoenix.html) or [integrating AppSignal into Plug](/elixir/integrations/plug.html) guides.
 
 After the installation is complete, start your application. When the AppSignal
 OTP application starts, it looks for a valid configuration (e.g. an AppSignal
@@ -141,3 +141,4 @@ Uninstall AppSignal from your app by following the steps below. When these steps
 [elixir-repo]: https://github.com/appsignal/appsignal-elixir
 [docs-repo]: https://github.com/appsignal/appsignal-docs
 [phoenix]: http://www.phoenixframework.org/
+[plug]: https://github.com/elixir-plug/plug

--- a/source/elixir/installation/umbrella.html.md
+++ b/source/elixir/installation/umbrella.html.md
@@ -12,7 +12,9 @@ Add the AppSignal dependency to each application that will use it. This includes
 
 ```elixir
 defp deps do
-  {:appsignal, "~> 2.0"}
+  [
+    {:appsignal, "~> 2.0"}
+  ]
 end
 ```
 

--- a/source/elixir/installation/upgrading-from-1.x-to-2.x.html.md
+++ b/source/elixir/installation/upgrading-from-1.x-to-2.x.html.md
@@ -23,8 +23,11 @@ existing dependency on `:appsignal`, and replace it with a dependency on
 `:appsignal_phoenix`.
 
 ```elixir
+# mix.exs
 defp deps do
-  {:appsignal_phoenix, "~> 2.0"}
+  [
+    {:appsignal_phoenix, "~> 2.0"}
+  ]
 end
 ```
 

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -13,14 +13,14 @@ instrumentation](/elixir/instrumentation/index.html) documentation.
 More information can be found in the [AppSignal Hex package
 documentation][hex-appsignal].
 
-## Getting started
+## Installation
 
-Since version 2.0, the Phoenix integration is moved to a separate library named
-`:appsignal_phoenix`, which depends on the main `:appsignal` library. To use
-AppSignal in a Phoenix app, add `:appsignal_phoenix` to your dependencies. You
-can then remove the `:appsignal` dependency.
+-> Upgrading from AppSignal for Elixir 1.0? Please read [our upgrade guide](/elixir/installation/upgrading-from-1.x-to-2.x.html).
+
+The AppSignal instrumentation for Phoenix is part of a separate package, which depends on the primary `appsignal` package. Add the `appsignal_phoenix` package to your `mix.exs` file.
 
 ``` elixir
+# mix.exs
 defmodule AppsignalPhoenixExample.MixProject do
   # ...
 
@@ -31,8 +31,6 @@ defmodule AppsignalPhoenixExample.MixProject do
       # ...
     ]
   end
-
-  # ...
 end
 ```
 

--- a/source/elixir/integrations/phoenix.html.md
+++ b/source/elixir/integrations/phoenix.html.md
@@ -27,8 +27,8 @@ defmodule AppsignalPhoenixExample.MixProject do
   defp deps do
     [
       {:phoenix, "~> 1.5.3"},
+      {:appsignal_phoenix, "~> 2.0"}
       # ...
-      {:appsignal_phoenix, "~> 2.0.0"}
     ]
   end
 

--- a/source/elixir/integrations/plug.html.md
+++ b/source/elixir/integrations/plug.html.md
@@ -16,6 +16,29 @@ instrumentation](/elixir/instrumentation/index.html) documentation.
 More information can be found in the [AppSignal Hex package
 documentation][hex-appsignal].
 
+## Installation
+
+-> Upgrading from AppSignal for Elixir 1.0? Please read [our upgrade guide](/elixir/installation/upgrading-from-1.x-to-2.x.html).
+
+The AppSignal instrumentation for Plug is part of a separate package, which depends on the primary `appsignal` package. Add the `appsignal_plug` package to your `mix.exs` file.
+
+```elixir
+# mix.exs
+defmodule AppsignalPlugExample.MixProject do
+  # ...
+
+  defp deps do
+    [
+      {:plug, "~> 1.0"}, # Or plug_cowboy ~> 2.0
+      {:appsignal_plug, "~> 2.0"}
+      # ...
+    ]
+  end
+end
+```
+
+If you're already using our `appsignal_phoenix` package, it's not necessary to add the `appsignal_plug` package as it's already a dependency of the `appsignal_phoenix` package. See also our [Phoenix integration guide](phoenix.html).
+
 ## Incoming HTTP requests
 
 We'll start out with a small Plug app that accepts `GET` requests to `/` and
@@ -36,7 +59,7 @@ defmodule AppsignalPlugExample do
 end
 ```
 
-This will create a transaction for every HTTP request which is performed on the 
+This will create a transaction for every HTTP request which is performed on the
 endpoint.
 
 ## Custom instrumentation


### PR DESCRIPTION
## Fix Elixir deps methods return values

Fix `mix.exs` file `deps` functions that don't return a list of
dependencies. I think it should always be a list.

## Relax Phoenix Elixir version lock

This way people only get patch updates, and not minor updates.
Everywhere else we lock only on the major or minor version, and for
Elixir packages only on the minor version.

## Link to upgrade guide from Phoenix integration

Refer to the upgrade guide about how to upgrade. Not mention this in
the main docs for Phoenix.

## Update Elixir Plug installation instructions

Mention how to install the appsignal_plug package in the Plug
instructions for Plug-only apps.
