### PR TITLE
Update Elixir docs for instrument with span arg

### DIFF
--- a/source/elixir/instrumentation/instrumentation.html.md
+++ b/source/elixir/instrumentation/instrumentation.html.md
@@ -72,7 +72,7 @@ created using the `Appsignal.instrument/2` function:
 
 ```elixir
 defmodule AppsignalElixirExample do
-  def instrument do
+  def example_fn do
     Appsignal.instrument("instrument", fn ->
       :timer.sleep(500)
     end)
@@ -86,7 +86,7 @@ span. To use a different category name, use `instrument/3` instead:
 
 ```elixir
 defmodule AppsignalElixirExample do
-  def instrument do
+  def example_fn do
     Appsignal.instrument("instrument", "call.instrument", fn ->
       :timer.sleep(500)
     end)
@@ -98,7 +98,7 @@ When passing a function that takes an argument, the `instrument/2-3` function ca
 
 ```elixir
 defmodule AppsignalElixirExample do
-  def instrument do
+  def example_fn do
     Appsignal.instrument("prepare_query.sql", "Build complicated SQL query", fn span ->
       # Example of building a complex SQL query in the instrument block and performing it
       query = "SOME complicate SQL query"

--- a/source/elixir/instrumentation/instrumentation.html.md
+++ b/source/elixir/instrumentation/instrumentation.html.md
@@ -94,15 +94,17 @@ defmodule AppsignalElixirExample do
 end
 ```
 
-When passing a function that takes an argument, the `instrument/2-3` function
-calls it with the opened span to allow further customization:
+When passing a function that takes an argument, the `instrument/2-3` function calls it with the opened span to allow further customization. See the docs on hex.pm for [all available Span functions](https://hexdocs.pm/appsignal/Appsignal.Span.html).
 
 ```elixir
 defmodule AppsignalElixirExample do
   def instrument do
-    Appsignal.instrument("instrument", "call.instrument", fn span ->
-      Appsignal.Span.set_namespace(span, "custom_namespace")
-      :timer.sleep(500)
+    Appsignal.instrument("prepare_query.sql", "Build complicated SQL query", fn span ->
+      # Example of building a complex SQL query in the instrument block and performing it
+      query = "SOME complicate SQL query"
+      # The body is only set here because it's the value being calculated and instrumented in this function
+      Appsignal.Span.set_sql(span, query)
+      Database.perform_query(query)
     end)
   end
 end


### PR DESCRIPTION
Users shouldn't set namespaces on child spans. That will either have no
effect or the span will not appear in the performance event timeline.

Even worse, in my limited testing, adding this line will cause the
sample not to show up on AppSignal.com at all.