### PR TITLE
Add sendParams config option for Node.js

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -968,6 +968,11 @@ options:
       since: 1.10.0
       type: bool
       default_value: true
+    nodejs:
+      config_key: sendParams
+      since: 2.2.8
+      type: bool
+      default_value: true
     description: |
       Whether to skip sending request parameters to AppSignal.
 


### PR DESCRIPTION
The Node.js integration now has the `sendParams` config option
available. This commit adds the required information about it.

__WARNINGS__
- Don't merge until https://github.com/appsignal/appsignal-nodejs/pull/537 is released
- Check `since` version number to match with correct version before merging