### PR TITLE
Add more details to the log stdout explanation

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -498,8 +498,8 @@ options:
       - `file` (default)
         - Write all AppSignal logs to the file system.
       - `stdout` (default on [Heroku](http://heroku.com/))
-        - Print AppSignal logs in the parent process' STDOUT.
-          Useful with hosting solutions such as container systems and Heroku. The log file will still be created and agent will still write to it even if you set the log setting to STDOUT.
+        - Print AppSignal logs in the parent process' STDOUT instead of to a file.
+          Useful with hosting solutions such as container systems and Heroku.
 
       -> **Note**: At this time only the AppSignal integration supports the "stdout" log output feature. The [AppSignal agent](/appsignal/how-appsignal-operates.html), which is used by the integration, does not support "stdout" log output. It will always write to the "appsignal.log" file.
   - config_key: log_path

--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -498,8 +498,8 @@ options:
       - `file` (default)
         - Write all AppSignal logs to the file system.
       - `stdout` (default on [Heroku](http://heroku.com/))
-        - Print AppSignal logs in the parent process' STDOUT instead of to a file.
-          Useful with hosting solutions such as container systems and Heroku.
+        - Print AppSignal logs in the parent process' STDOUT.
+          Useful with hosting solutions such as container systems and Heroku. The log file will still be created and agent will still write to it even if you set the log setting to STDOUT.
 
       -> **Note**: At this time only the AppSignal integration supports this feature and the [AppSignal agent](/appsignal/how-appsignal-operates.html), which is used by the integration, does not yet support this.
   - config_key: log_path

--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -501,7 +501,7 @@ options:
         - Print AppSignal logs in the parent process' STDOUT.
           Useful with hosting solutions such as container systems and Heroku. The log file will still be created and agent will still write to it even if you set the log setting to STDOUT.
 
-      -> **Note**: At this time only the AppSignal integration supports this feature and the [AppSignal agent](/appsignal/how-appsignal-operates.html), which is used by the integration, does not yet support this.
+      -> **Note**: At this time only the AppSignal integration supports the "stdout" log output feature. The [AppSignal agent](/appsignal/how-appsignal-operates.html), which is used by the integration, does not support "stdout" log output. It will always write to the "appsignal.log" file.
   - config_key: log_path
     env_key: APPSIGNAL_LOG_PATH
     ruby:


### PR DESCRIPTION
When setting the `log` to `stdout` the agent still creates the log file and writes to it.