### PR TITLE
Add sendSessionData config option docs

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -988,6 +988,15 @@ options:
       default_value: false
     description: |
       Set this option to `true` to not send any session data with exception traces and performance issue samples.
+  - config_key: send_session_data
+    env_key: APPSIGNAL_SEND_SESSION_DATA
+    nodejs:
+      config_key: sendSessionData
+      since: 2.2.9
+      type: bool
+      default_value: true
+    description: |
+      Set this option to `false` to not send any session data with exception traces and performance issue samples.
   - config_key: working_dir_path
     env_key: APPSIGNAL_WORKING_DIR_PATH
     ruby:

--- a/source/application/session-data-filtering.html.md
+++ b/source/application/session-data-filtering.html.md
@@ -18,10 +18,11 @@ Any session data values that are filtered out by these systems will be replaced 
 
 ## Filter all session data
 
-To filter all session data without individual key filtering, set "skip session data" config option to "true" in the integration configuration.
+To filter all session data without individual key filtering, set "skip session data" config option to "true" in the integration configuration. Or set "send session data" to "false" if that's the supported option.
 
 - [Ruby `skip_session_data` config option documentation](/ruby/configuration/options.html#option-skip_session_data)
 - [Elixir `skip_session_data` config option documentation](/elixir/configuration/options.html#option-skip_session_data)
+- [Node.js `send_session_data` config option documentation](/nodejs/configuration/options.html#option-send_session_data)
 
 ## Recommended keys to filter
 

--- a/source/appsignal/gdpr.html.md
+++ b/source/appsignal/gdpr.html.md
@@ -48,7 +48,7 @@ Any non-allowlisted headers are stripped before being sent to AppSignal.
 
 We've had filtering options for _parameters_ for a long time already, but in our [parameter filtering documentation](/application/parameter-filtering.html) we now stress the importance with regard to GDPR.
 
-Recent Ruby gem and Elixir package releases expand this filtering feature to [session data](/application/session-data-filtering.html) too. It allows customers to send parameters to AppSignal without exposing personal data, by replacing that data with `[FILTERED]`. Alternatively, a customer can choose to not send any parameters ([Ruby](/ruby/configuration/options.html#option-send_params)) or session data ([Ruby](/ruby/configuration/options.html#option-skip_session_data) / [Elixir](/elixir/configuration/options.html#option-skip_session_data)) at all.
+Recent Ruby gem, Elixir package and Node.js package releases expand this filtering feature to [session data](/application/session-data-filtering.html) too. It allows customers to send parameters to AppSignal without exposing personal data, by replacing that data with `[FILTERED]`. Alternatively, a customer can choose to not send any parameters ([Ruby](/ruby/configuration/options.html#option-send_params)) or session data ([Ruby](/ruby/configuration/options.html#option-skip_session_data) / [Elixir](/elixir/configuration/options.html#option-skip_session_data) / [Node.js]((/nodejs/configuration/options.html#option-send_session_data))) at all.
 
 Data is filtered before being sent to AppSignal.
 


### PR DESCRIPTION
The `sendSessionData` config option has been added to the Node.js
integration.

**WARNING**

- Do not merge until https://github.com/appsignal/appsignal-nodejs/pull/541 is released
- Review `since` version number to match the release