### PR TITLE
Update Node.js minutely probes documentation

### DIFF
--- a/source/nodejs/integrations/core.html.md
+++ b/source/nodejs/integrations/core.html.md
@@ -4,10 +4,24 @@ title: "Node.js Core"
 
 Node.js contains several internal modules designed to enable asynchronous I/O capable APIs for your application. AppSignal provides automatic instrumentation for many of these modules.
 
-## `http`
+## `http` instrumentation
 
 AppSignal for Node.js will auto-instrument any incoming HTTP calls. When you create a new `Span`, it will be a child of the `Span` created by the core HTTP integration.
 
-## `https`
+## `https` instrumentation
 
 Appsignal for Node.js will also auto-instrument any incoming HTTPS calls. When you create a new `Span`, it will be a child of the `Span` created by the core HTTPS integration, if the `https` module was used.
+
+## Heap statistics minutely probe
+
+By default, Appsignal for Node.js will register a minutely probe that keeps track of the V8 engine's heap statistics. Once we detect these metrics we'll add a [magic dashboard](https://blog.appsignal.com/2019/03/27/magic-dashboards.html) to your app.
+
+The metrics reported by this method correspond to those reported by the `v8.getHeapStatistics` method in the Node.js standard library. For more details on how to interpret these metrics, [see the official Node.js documentation on the `v8` module](https://nodejs.org/api/v8.html#v8getheapstatistics). The probe will report the following metrics grouped by `hostname` tag:
+
+- `nodejs_total_heap_size` - gauge
+- `nodejs_total_heap_size_executable` - gauge
+- `nodejs_total_physical_size` - gauge
+- `nodejs_used_heap_size` - gauge
+- `nodejs_malloced_memory` - gauge
+- `nodejs_number_of_native_contexts` - gauge
+- `nodejs_number_of_detached_contexts` - gauge

--- a/source/nodejs/metrics/minutely-probes.html.md
+++ b/source/nodejs/metrics/minutely-probes.html.md
@@ -2,15 +2,13 @@
 title: "Minutely probes"
 ---
 
-Minutely probes are a mechanism to periodically send custom metrics to AppSignal. In minutely intervals from when the probe was first created, a user-defined function can be called in which you can capture metrics to send them to AppSignal. As minutely probes are instances of `EventEmitter`s, they are asynchronous.
+Minutely probes are a mechanism to periodically send custom metrics to AppSignal. In minutely intervals from when the probe was first created, a user-defined function can be called in which you can capture metrics to send them to AppSignal. Minutely probe functions are ran asynchronously.
 
-No minutely probes are configured by `@appsignal/nodejs` by default.
-
-Minutely probes can be enabled/disabled with the [`enableMinutelyProbes`](/nodejs/configuration/options.html#option-enableminutelyprobes) config option.
+Starting with version `2.3.0`, you can enable or disable minutely probes entirely with the [`enableMinutelyProbes`](/nodejs/configuration/options.html#option-enableminutelyprobes) config option.
 
 ## Creating probes
 
-If you need to track custom metrics from your app, you can add your own probe(s). Using a probe will be familiar to you if you have used an `EventEmitter` before; the `probes.register()` method takes two arguments: a probe name and an anonymous function to be called once every minute.
+If you need to track custom metrics from your app, you can add your own probe(s). To register a probe, you must call the `probes.register()` method with two arguments: a probe name, and an anonymous function to be called once every minute.
 
 ```js
 const meter = appsignal.metrics();
@@ -23,4 +21,16 @@ probes.register("database", () => {
 });
 ```
 
-As with most, if not all, usages of an `EventEmitter`, it is crucial not to block the event loop for long periods inside a minutely probe callback.
+To ensure all minutely probes are ran in a timely manner, it is important to avoid blocking the event loop for long periods inside a minutely probe callback.
+
+## Overriding default probes
+
+By default, `@appsignal/nodejs` configures a minutely probe which keeps track of Node.js V8 heap statistics. To disable this probe, use `probes.unregister()`:
+
+```js
+const probes = appsignal.metrics().probes();
+
+probes.unregister("v8_stats");
+```
+
+Before version `2.3.0`, `probes.unregister()` is not available. In versions before `2.3.0`, you can use the [`enableMinutelyProbes`](/nodejs/configuration/options.html#option-enableminutelyprobes) config option to disable the default probe.


### PR DESCRIPTION
This commit updates the documentation about Node.js minutely probes to document the existence of the default minutely probe (fixes #532), including the hostname tag added in appsignal/appsignal-nodejs#543. It also documents how to disable the default minutely probe and how to disable the minutely probe system, taking into account the change in behaviour for the `enableMinutelyProbes` config option introduced in appsignal/appsignal-nodejs#547.

I also removed several references about the probes system being an `EventEmitter`. While this is technically true, using it as an `EventEmitter` directly makes no sense in the context of how the probes are meant to be used. You can't simply register a listener and expect it to be called every minute; instead, you have to use the `register` method we provide for that to happen, which means there's no point to all the wording about how its usage should be familiar because it's just an `EventEmitter`. In fact, we should probably just _use_ an `EventEmitter` internally, instead of `Probes` extending `EventEmitter`.

@shairyar Feel free to change anything in this PR as you see fit for the Node.js documentation revamp 📖💪