### PR TITLE
Update Node.js installation docs

### DIFF
--- a/source/nodejs/installation.html.md
+++ b/source/nodejs/installation.html.md
@@ -51,7 +51,11 @@ const appsignal = new Appsignal({
 // ...all the rest of your code goes here!
 ```
 
-!> To auto-instrument modules, the Appsignal module must be both **required** and **initialized** before any other package.
+!> To auto-instrument modules, the `Appsignal` module must be both **required** and **initialized** before any other package.
+
+### Adding integrations
+
+AppSignal supports several libraries and frameworks with additional packages, such as Express, Koa, Next.js and more. Additional installation instructions for these packages can be found in the [Node.js integrations section](/nodejs/integrations).
 
 ---
 

--- a/source/nodejs/instrumentation/instrumentation.html.md
+++ b/source/nodejs/instrumentation/instrumentation.html.md
@@ -6,6 +6,8 @@ In order to find out what specific pieces of code are causing performance proble
 
 -> **Note**: Make sure you've [installed AppSignal](/nodejs/installation.html) before adding custom instrumentation to your application if it's not integrated by one of our supported [integrations](/nodejs/integrations/index.html).
 
+-> **Note**: This page only describes how to add performance instrumentation to your code. To track errors please read our [exception handling](/nodejs/instrumentation/exception-handling.html) guide.
+
 ## The Tracer object
 
 The `Tracer` object provided by the AppSignal for Node.js integration contains various functions that you might use when creating your own custom instrumentation.

--- a/source/nodejs/instrumentation/instrumentation.html.md
+++ b/source/nodejs/instrumentation/instrumentation.html.md
@@ -4,6 +4,8 @@ title: "Custom instrumentation for Node.js"
 
 In order to find out what specific pieces of code are causing performance problems it's useful to add custom instrumentation to your application. This allows us to create better breakdowns of which code runs slowest and what type of action the most amount of time was spent on.
 
+-> **Note**: Make sure you've [installed AppSignal](/nodejs/installation.html) before adding custom instrumentation to your application if it's not integrated by one of our supported [integrations](/nodejs/integrations/index.html).
+
 ## The Tracer object
 
 The `Tracer` object provided by the AppSignal for Node.js integration contains various functions that you might use when creating your own custom instrumentation.


### PR DESCRIPTION
## Link to Node.js packages in install guide

Users may not know we have additional packages to integrate with other
libraries. Link to these from the install page, like we do in the Elixir
installation guide.

## Link to install guide from instrumentation page

Like we do for Elixir and Ruby, link to the page that will help users
get AppSignal set up before they add extra instrumentation.
Otherwise it won't work.

## Link to Node.js exception handling page

Like we do for Elixir and Ruby, link to the exception handling page
from the instrumentation page. This way users won't assume it does
both.
