### PR TITLE
Update Node.js custom instrumentation page

### DIFF
--- a/source/nodejs/instrumentation/instrumentation.html.md
+++ b/source/nodejs/instrumentation/instrumentation.html.md
@@ -121,10 +121,9 @@ When called with a single argument, the `value` will be applied to the span as t
 const tracer = appsignal.tracer();
 const rootSpan = tracer.rootSpan();
 const childSpan = rootSpan.child();
-const queryObj = "YOUR-QUERY";
 childSpan.setName("Query.sql.model.action");
 childSpan.setCategory("get.query");
-childSpan.setSQL(queryObj);
+childSpan.setSQL("SELECT * FROM users WHERE email = 'hello@example.com'");
 ```
 #### Adding metadata to a Span
 
@@ -158,10 +157,9 @@ Here is an example of creating a child span from the current root span, adding i
 const tracer = appsignal.tracer();
 const rootSpan = tracer.rootSpan();
 const childSpan = rootSpan.child();
-const queryObj = "YOUR-QUERY";
 childSpan.setName("Query.sql.model.action");
 childSpan.setCategory("get.query");
-childSpan.setSQL(queryObj);
+childSpan.setSQL("SELECT * FROM users WHERE email = 'hello@example.com'");
 
 // do stuff...
 

--- a/source/nodejs/instrumentation/instrumentation.html.md
+++ b/source/nodejs/instrumentation/instrumentation.html.md
@@ -16,11 +16,13 @@ The Tracer is responsible for tracking the current root and active `Span`s, and 
 
 ### Retrieving the Tracer
 
+The tracer object can be retrieved by calling the `tracer()` function on the `Appsignal` client object.
+
 ```js
 const tracer = appsignal.tracer();
 ```
 
-If the agent is currently inactive (you must set it as such yourself, by setting `active: true`), then the AppSignal client will return a tracer object that does nothing. It is safe to call this tracer object within your code as you would if the integration was active, but it will not record any data.
+If AppSignal is configured to not be active (`active: false`), the AppSignal client will return a tracer object that will not record any data. It is safe to call this tracer object within your code as you would if the integration was active.
 
 ## Creating and using a Span
 

--- a/source/nodejs/instrumentation/instrumentation.html.md
+++ b/source/nodejs/instrumentation/instrumentation.html.md
@@ -12,7 +12,7 @@ In order to find out what specific pieces of code are causing performance proble
 
 The `Tracer` object provided by the AppSignal for Node.js integration contains various functions that you might use when creating your own custom instrumentation.
 
-The Tracer is responsible for tracking the currently active `Span`, and exposes functions for creating and activating new `Span`s.
+The Tracer is responsible for tracking the current root and active `Span`s, and exposes functions for creating and activating new Spans. We will discuss these functions on this page in more detail.
 
 ### Retrieving the Tracer
 
@@ -28,11 +28,12 @@ A Span is the name of the object that we use to capture data about the performan
 
 Each Span contains the following metadata:
 
+- The parent Spans ID (if any)
+- A start and finish time
 - A name
-- A start and finish timestamp
-- Tags
-- Sample data
-- The parent `Span`s ID (if any)
+- A category
+- Sample data (RootSpan only)
+- Tags (RootSpan only)
 
 It is designed to closely follow the concept of a Span from the [OpenTelemetry standard specification](https://github.com/open-telemetry/opentelemetry-specification), but there are some minor differences that we'll get into later.
 

--- a/source/nodejs/instrumentation/instrumentation.html.md
+++ b/source/nodejs/instrumentation/instrumentation.html.md
@@ -32,10 +32,13 @@ Each Span contains the following metadata:
 
 - The parent Spans ID (if any)
 - A start and finish time
-- A name
+- A name (RootSpan only)
+    - The action name for requests and background jobs, e.g. `GET /user/profile` and `BackgroundJob.perform`. Requests and background jobs are grouped together by this name.
 - A category
-- Sample data (RootSpan only)
-- Tags (RootSpan only)
+    - The name of the event shown in the performance event timeline, e.g. `fetch_all.user_service` and `render.handlebars`.
+- [Error data](/nodejs/instrumentation/exception-handling.html) (RootSpan only)
+- [Sample data](/guides/custom-data/sample-data.html) (RootSpan only)
+- [Tags](/guides/custom-data/tagging-request.html) (RootSpan only)
 
 It is designed to closely follow the concept of a Span from the [OpenTelemetry standard specification](https://github.com/open-telemetry/opentelemetry-specification), but there are some minor differences that we'll get into later.
 


### PR DESCRIPTION
## Update Node.js setSQL example

Update the example to show usage of an actual query.
It leaves less to the imagination and is easier to understand.

## Clarify differences between root and child spans

Document what types of data can and can't bet set on certain types
of Spans.

## Expand Node.js Tracer docs

Explain a bit more clearly what happens when AppSignal is not active.

## Clarify Node.js span metadata

Describe in a bit more words what the different types of Span metadata
are and link to other pages if they contain relevant information.

## Update Node.js custom instrumentation page

Update how the custom instrumentation should be used and the different
metadata purpose.

- `setName` is used for the "action name" as reported for AppSignal
  incidents.
- `setCategory` is used to set "event names" as shown in the event
  timeline.
