### PR TITLE
Broken link filter params

### DIFF
--- a/data/config_options.yml
+++ b/data/config_options.yml
@@ -978,7 +978,7 @@ options:
     description: |
       Whether to skip sending request parameters to AppSignal.
 
-      For more information please read about [send_params](parameter-filtering.html#filter-all-parameters) in filtering request parameters.
+      For more information please read about [send_params](/application/parameter-filtering.html) in filtering request parameters.
   - config_key: skip_session_data
     env_key: APPSIGNAL_SKIP_SESSION_DATA
     ruby:

--- a/source/application/parameter-filtering.html.md
+++ b/source/application/parameter-filtering.html.md
@@ -24,6 +24,7 @@ To filter all parameters without individual parameter filtering, set "send param
 
 - [Ruby `send_params` config option documentation](/ruby/configuration/options.html#option-send_params)
 - [Elixir `send_params` config option documentation](/elixir/configuration/options.html#option-send_params)
+- [Node.js `sendParams` config option documentation](/nodejs/configuration/options.html#option-sendparams)
 
 ## Processor parameter filtering
 


### PR DESCRIPTION
## Fix link to param filtering from config opts list 

The link pointing to parameter filtering general information from the
config option documentation was broken. This commits fixes it by
pointing the link to the main parameter filtering page without an
anchor.

## Add Node.js sendParams link in parameter filtering

The link to the Node.js integration docs for `sendParams` was missing on
Parameter filtering main page.