### PR TITLE
Clarify when the sourcemap endpoint returns a 404

### DIFF
--- a/source/api/sourcemaps.html.md
+++ b/source/api/sourcemaps.html.md
@@ -83,7 +83,7 @@ All parameters, except for `file` can be sent either in the POST body or as GET 
 
 - The API will return a `201` HTTP status code if successful.
 - The API will return a `400` HTTP status code with a JSON response when a validation error has occurred.
-- The API will return a `404` HTTP status code if no site exists for the given app name, environment and API key.
+- The API will return a `404` HTTP status code if no app exists for the given app name, environment and Push API key combination.
 
 400 response body example:
 

--- a/source/api/sourcemaps.html.md
+++ b/source/api/sourcemaps.html.md
@@ -83,7 +83,7 @@ All parameters, except for `file` can be sent either in the POST body or as GET 
 
 - The API will return a `201` HTTP status code if successful.
 - The API will return a `400` HTTP status code with a JSON response when a validation error has occurred.
-- The API will return a `404` HTTP status code if none of the referenced objects can be found.
+- The API will return a `404` HTTP status code if no site exists for the given app name, environment and API key.
 
 400 response body example:
 


### PR DESCRIPTION
As seen in [this conversation](https://app.intercom.com/a/apps/yzor8gyw/inbox/inbox/conversation/16410700105222), "referenced object" is confusing. This clarifies that the object that might not be found is the site.

Feel free to tweak the wording.